### PR TITLE
Fix P1: Change default language from German to English

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finance-news
-description: "Market news briefings with AI summaries in German. Features: Portfolio tracking, multi-market coverage (US/Europe/Japan), cron-scheduled WhatsApp briefings, WSJ/Barron's/CNBC/Yahoo aggregation."
+description: "Market news briefings with AI summaries. Features: Portfolio tracking, multi-market coverage (US/Europe/Japan), cron-scheduled WhatsApp briefings, WSJ/Barron's/CNBC/Yahoo aggregation, English/German language support."
 ---
 
 # Finance News Skill
@@ -19,7 +19,7 @@ The wizard will guide you through:
 - 📰 **RSS Feeds:** Enable/disable WSJ, Barron's, CNBC, Yahoo, etc.
 - 📊 **Markets:** Choose regions (US, Europe, Japan, Asia)
 - 📤 **Delivery:** Configure WhatsApp/Telegram group
-- 🌐 **Language:** Set default language (German/English)
+- 🌐 **Language:** Set default language (English/German)
 - ⏰ **Schedule:** Configure morning/evening cron times
 
 You can also configure specific sections:
@@ -61,24 +61,27 @@ finance-news news AAPL
 
 ### 🤖 AI Summaries
 - Gemini-powered analysis
-- Configurable language (German/English)
+- Configurable language (English/German)
 - Briefing styles: summary, analysis, headlines
 
 ### 📅 Automated Briefings
 - **Morning:** 6:30 AM PT (US market open)
 - **Evening:** 1:00 PM PT (US market close)
-- **Delivery:** WhatsApp group "Niemand Boerse"
+- **Delivery:** WhatsApp (configure group in cron scripts)
 
 ## Commands
 
 ### Briefing Generation
 
 ```bash
-# Morning briefing in German
-finance-news briefing --morning --lang de
+# Morning briefing (English is default)
+finance-news briefing --morning
 
 # Evening briefing with WhatsApp delivery
-finance-news briefing --evening --send --group "Niemand Boerse"
+finance-news briefing --evening --send --group "Market Briefing"
+
+# German language option
+finance-news briefing --morning --lang de
 
 # Analysis style (more detailed)
 finance-news briefing --style analysis

--- a/config/sources.json
+++ b/config/sources.json
@@ -41,7 +41,7 @@
     }
   },
   "language": {
-    "default": "de",
-    "supported": ["de", "en"]
+    "default": "en",
+    "supported": ["en", "de"]
   }
 }

--- a/cron/evening.sh
+++ b/cron/evening.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Evening Briefing Cron Job
 # Schedule: 1:00 PM PT (US Market Close at 4:00 PM ET)
-# Target: WhatsApp group "Niemand Boerse"
+# Target: WhatsApp group (configure --group flag)
 
 set -e
 
@@ -12,8 +12,8 @@ echo "[$(date)] Starting evening briefing..."
 python3 "$SCRIPT_DIR/scripts/briefing.py" \
     --time evening \
     --style briefing \
-    --lang de \
+    --lang en \
     --send \
-    --group "Niemand Boerse"
+    --group "Market Briefing"
 
 echo "[$(date)] Evening briefing complete."

--- a/cron/morning.sh
+++ b/cron/morning.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Morning Briefing Cron Job
 # Schedule: 6:30 AM PT (US Market Open at 9:30 AM ET)
-# Target: WhatsApp group "Niemand Boerse"
+# Target: WhatsApp group (configure --group flag)
 
 set -e
 
@@ -12,8 +12,8 @@ echo "[$(date)] Starting morning briefing..."
 python3 "$SCRIPT_DIR/scripts/briefing.py" \
     --time morning \
     --style briefing \
-    --lang de \
+    --lang en \
     --send \
-    --group "Niemand Boerse"
+    --group "Market Briefing"
 
 echo "[$(date)] Morning briefing complete."

--- a/scripts/briefing.py
+++ b/scripts/briefing.py
@@ -92,7 +92,7 @@ def main():
                         help='Briefing type (auto-detected if not specified)')
     parser.add_argument('--style', choices=['briefing', 'analysis', 'headlines'],
                         default='briefing', help='Summary style')
-    parser.add_argument('--lang', choices=['de', 'en'], default='de',
+    parser.add_argument('--lang', choices=['en', 'de'], default='en',
                         help='Output language')
     parser.add_argument('--send', action='store_true',
                         help='Send to WhatsApp group')


### PR DESCRIPTION
## Changes

Makes English the default language to broaden skill adoption.

### Updated files
- ✅ **config/sources.json:** `default: "en"`, order: `en, de`
- ✅ **scripts/briefing.py:** `--lang default='en'`, order: `en, de`
- ✅ **cron/morning.sh:** `--lang en`, generic group name
- ✅ **cron/evening.sh:** `--lang en`, generic group name
- ✅ **SKILL.md:** English examples first, German shown as option

### Testing
```bash
# Default is now English
finance-news briefing --morning

# German still works
finance-news briefing --morning --lang de
```

### Impact
- ✅ Makes skill accessible to wider audience
- ✅ German support fully preserved (use `--lang de`)
- ✅ Config and cron scripts updated consistently

Fixes #17