### PR TITLE
fix: calculate change_percent when null from openbb-quote

### DIFF
--- a/scripts/fetch_news.py
+++ b/scripts/fetch_news.py
@@ -177,7 +177,11 @@ def fetch_market_data(symbols: list[str]) -> dict:
                 if data.get('change_percent') is None and data.get('price') and data.get('prev_close'):
                     price = data['price']
                     prev_close = data['prev_close']
-                    data['change_percent'] = ((price - prev_close) / prev_close) * 100
+                    
+                    # Guard against division by zero (rare but possible for new listings or data errors)
+                    if prev_close != 0:
+                        data['change_percent'] = ((price - prev_close) / prev_close) * 100
+                    # If prev_close is 0, leave change_percent as None (no valid calculation)
                 
                 results[symbol] = data
         except subprocess.TimeoutExpired:


### PR DESCRIPTION
## Problem

Briefings incorrectly reported all stocks as "unchanged" even when they had significant moves (e.g., MSFT -2.32%, GOOGL +1.57%).

**Root cause:** `openbb-quote` returns `change_percent: null`, which defaults to 0 in the code:
```python
change_pct = quote.get('change_percent', 0)  # Always 0!
```

## Solution

Calculate `change_percent` from `price` and `prev_close` when it's null:
```python
if data.get('change_percent') is None and data.get('price') and data.get('prev_close'):
    price = data['price']
    prev_close = data['prev_close']
    data['change_percent'] = ((price - prev_close) / prev_close) * 100
```

## Test Results

**Before:**
- AAPL: change_percent: null → defaults to 0%
- Briefing says: "aktuell unverändert" (currently unchanged) ❌

**After:**
- AAPL: $245.71 (prev $246.70) → -0.40% ✅
- MSFT: $443.96 (prev $454.54) → -2.32% ✅
- GOOGL: $327.05 (prev $321.99) → +1.57% ✅

## Impact

- ✅ Fixes briefing accuracy
- ✅ AI summaries will now reflect actual market moves
- ✅ Applies to both portfolio stocks and market indices