### PR TITLE
feat: Scalable briefing for large portfolios (#36)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 feedparser>=6.0.11
+yfinance


### PR DESCRIPTION
## Summary
Implements tiered fetching strategy to support 200+ stock portfolios within 10-minute timeout.

## Changes
- **Tiered Fetching:**
  - Fetches all prices first (batch mode via yfinance).
  - Identifies Top 10 movers (5 gainers, 5 losers).
  - Fetches news ONLY for these top 10 stocks.
- **Message Splitting:**
  - Splits briefing into 2 parts: Macro Overview + Portfolio Deep Dive.
  - Ensures WhatsApp limit (4k chars) isn't hit.
- **Performance:**
  - Uses `yfinance` Tickers for efficient batch fetching.
  - Skips news calls for stable/minor positions.

## Related Issues
- Closes #36