### PR TITLE
feat: Add earnings/analyst context functions (#37)

### DIFF
--- a/scripts/earnings.py
+++ b/scripts/earnings.py
@@ -18,6 +18,8 @@ import argparse
 import csv
 import json
 import os
+import shutil
+import subprocess
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -31,6 +33,17 @@ CACHE_DIR = SCRIPT_DIR.parent / "cache"
 PORTFOLIO_FILE = CONFIG_DIR / "portfolio.csv"
 EARNINGS_CACHE = CACHE_DIR / "earnings_calendar.json"
 MANUAL_EARNINGS = CONFIG_DIR / "manual_earnings.json"  # For JP/other stocks not in Finnhub
+
+# OpenBB binary path
+OPENBB_BINARY = None
+try:
+    env_path = os.environ.get('OPENBB_QUOTE_BIN')
+    if env_path and os.path.isfile(env_path) and os.access(env_path, os.X_OK):
+        OPENBB_BINARY = env_path
+    else:
+        OPENBB_BINARY = shutil.which('openbb-quote')
+except Exception:
+    pass
 
 # API Keys
 def get_fmp_key() -> str:
@@ -384,16 +397,82 @@ def get_briefing_section() -> str:
     """Get earnings section for daily briefing (called by briefing.py)."""
     from io import StringIO
     import contextlib
-    
+
     # Capture check output
     class Args:
         verbose = False
-    
+
     f = StringIO()
     with contextlib.redirect_stdout(f):
         check_earnings(Args())
-    
+
     return f.getvalue()
+
+
+def get_earnings_context(symbols: list[str]) -> list[dict]:
+    """
+    Get recent earnings data (beats/misses) for symbols using OpenBB.
+
+    Returns list of dicts with: symbol, eps_actual, eps_estimate, surprise, revenue_actual, revenue_estimate
+    """
+    if not OPENBB_BINARY:
+        return []
+
+    results = []
+    for symbol in symbols[:10]:  # Limit to 10 symbols
+        try:
+            result = subprocess.run(
+                [OPENBB_BINARY, symbol, '--earnings'],
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+            if result.returncode == 0:
+                try:
+                    data = json.loads(result.stdout)
+                    if isinstance(data, list) and data:
+                        results.append({
+                            'symbol': symbol,
+                            'earnings': data[0] if isinstance(data[0], dict) else {}
+                        })
+                except json.JSONDecodeError:
+                    pass
+        except Exception:
+            pass
+    return results
+
+
+def get_analyst_ratings(symbols: list[str]) -> list[dict]:
+    """
+    Get analyst upgrades/downgrades for symbols using OpenBB.
+
+    Returns list of dicts with: symbol, rating, target_price, firm, direction
+    """
+    if not OPENBB_BINARY:
+        return []
+
+    results = []
+    for symbol in symbols[:10]:  # Limit to 10 symbols
+        try:
+            result = subprocess.run(
+                [OPENBB_BINARY, symbol, '--rating'],
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+            if result.returncode == 0:
+                try:
+                    data = json.loads(result.stdout)
+                    if isinstance(data, list) and data:
+                        results.append({
+                            'symbol': symbol,
+                            'rating': data[0] if isinstance(data[0], dict) else {}
+                        })
+                except json.JSONDecodeError:
+                    pass
+        except Exception:
+            pass
+    return results
 
 
 def main():


### PR DESCRIPTION
## Summary

Added functions to fetch earnings and analyst rating data for integration into briefings.

### Changes

- usage: earnings.py [-h] {list,check,refresh} ...

Earnings Calendar Tracker

positional arguments:
  {list,check,refresh}  Commands
    list                List all upcoming earnings
    check               Check today/this week
    refresh             Force refresh all data

options:
  -h, --help            show this help message and exit:
  - Added  - fetches EPS beats/misses using OpenBB
  - Added  - fetches upgrades/downgrades using OpenBB
  - Both functions limit to 10 symbols for performance

### Integration

These functions can be called from  to include earnings context in briefings.

Closes #37