### PR TITLE
fix: Briefing quality issues - URLs, ranking, feed filter (#69)

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -34,8 +34,8 @@
     "reuters": {
       "name": "Reuters",
       "enabled": true,
-      "markets": "https://news.google.com/rss/search?q=site%3Areuters.com&hl=en-US&gl=US&ceid=US%3Aen",
-      "note": "Google News RSS wrapper for Reuters."
+      "markets": "https://news.google.com/rss/search?q=site%3Areuters.com+markets+OR+stocks+OR+economy+OR+fed+OR+earnings&hl=en-US&gl=US&ceid=US%3Aen",
+      "note": "Google News RSS wrapper for Reuters - filtered for finance/markets."
     },
     "ft": {
       "name": "Financial Times",


### PR DESCRIPTION
## Fixes for Briefing Quality Issues

### 1. URL Shortening Fixed
- Changed from POST to GET for is.gd API (POST returns 403)
- Added User-Agent header
- URLs now properly shortened

### 2. Deterministic Ranking Integrated
- Uses new `rank_headlines()` for impact-based scoring
- **Source cap**: max 2 headlines per outlet (no more 5x Reuters)
- **Diversity quotas**: ensures macro, equities, geopolitics coverage
- Falls back to LLM selection only if ranking fails

### 3. Reuters Feed Filtered
- Added finance keywords to Reuters Google News query
- Filters: `markets OR stocks OR economy OR fed OR earnings`
- Prevents non-finance stories (like tourist accidents)

### Testing
- URL shortening: `shorten_url(long_url)` returns `https://is.gd/xxx`
- Ranking: `rank_headlines(headlines)` returns diverse top 5

Closes #69