### PR TITLE
feat: add Lobster workflow and improve skill compliance

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finance-news
-description: "Market news briefings with AI summaries. Features: Portfolio tracking, multi-market coverage (US/Europe/Japan), cron-scheduled WhatsApp briefings, WSJ/Barron's/CNBC/Yahoo aggregation, English/German language support."
+description: "Market news briefings with AI summaries. Use when asked about stock news, market updates, portfolio performance, morning/evening briefings, financial headlines, or price alerts. Supports US/Europe/Japan markets, WhatsApp delivery, and English/German output."
 ---
 
 # Finance News Skill
@@ -210,23 +210,47 @@ The agent will automatically use this skill when asked about:
 - "Generate morning briefing"
 - "What's happening with AAPL?"
 
+### With Lobster (Workflow Engine)
+
+Run briefings via [Lobster](https://github.com/moltbot/lobster) for approval gates and resumability:
+
+```bash
+# Run with approval before WhatsApp send
+lobster "workflows.run --file workflows/briefing.yaml"
+
+# With custom args
+lobster "workflows.run --file workflows/briefing.yaml --args-json '{\"time\":\"evening\",\"lang\":\"en\"}'"
+```
+
+See `workflows/README.md` for full documentation.
+
 ## Files
 
 ```
 skills/finance-news/
 ├── SKILL.md              # This documentation
+├── Dockerfile            # NixOS-compatible container
 ├── config/
 │   ├── portfolio.csv     # Your watchlist
-│   └── config.json       # RSS/API configuration
+│   ├── config.json       # RSS/API/language configuration
+│   ├── alerts.json       # Price target alerts
+│   └── manual_earnings.json  # Earnings calendar overrides
 ├── scripts/
 │   ├── finance-news      # Main CLI
 │   ├── briefing.py       # Briefing generator
 │   ├── fetch_news.py     # News aggregator
 │   ├── portfolio.py      # Portfolio CRUD
-│   └── summarize.py      # Gemini summarization
+│   ├── summarize.py      # AI summarization
+│   ├── alerts.py         # Price alert management
+│   ├── earnings.py       # Earnings calendar
+│   ├── ranking.py        # Headline ranking
+│   └── stocks.py         # Stock management
+├── workflows/
+│   ├── briefing.yaml     # Lobster workflow with approval gate
+│   └── README.md         # Workflow documentation
 ├── cron/
-│   ├── morning.sh        # Morning cron script
-│   └── evening.sh        # Evening cron script
+│   ├── morning.sh        # Morning cron (Docker-based)
+│   └── evening.sh        # Evening cron (Docker-based)
 └── cache/                # 15-minute news cache
 ```
 

--- a/docs/EQUITY_SHEET_FIXES.md
+++ b/docs/EQUITY_SHEET_FIXES.md
@@ -1,5 +1,13 @@
 # Equity Sheet Fixes
 
+## Contents
+- [NRR Column Fix](#nrr-column-column-q---range-values-fix)
+- [Conversion Rules](#conversion-rules)
+- [Fix Procedure](#fix-procedure)
+- [Impact](#impact)
+- [Related Columns](#related-columns)
+- [Prevention](#prevention)
+
 ## NRR Column (Column Q) - Range Values Fix
 
 **Problem:** Values like "115-120%", "125%+", "N/A" in NRR column cause #VALUE! errors in MSS Score formula (columns Y/Z).

--- a/docs/PREMIUM_SOURCES.md
+++ b/docs/PREMIUM_SOURCES.md
@@ -1,5 +1,13 @@
 # Premium Source Authentication
 
+## Contents
+- [Overview](#overview)
+- [Option 1: Keep It Simple (Recommended)](#option-1-keep-it-simple-recommended)
+- [Option 2: Use Premium Sources (Advanced)](#option-2-use-premium-sources-advanced)
+- [Troubleshooting](#troubleshooting)
+- [Alternative: Use APIs Instead](#alternative-use-apis-instead)
+- [Recommendation](#recommendation)
+
 ## Overview
 
 WSJ and Barron's are premium financial news sources that require subscriptions. This guide explains how to authenticate and use premium sources with the finance-news skill.

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,97 @@
+# Lobster Workflows
+
+This directory contains [Lobster](https://github.com/moltbot/lobster) workflow definitions for the finance-news skill.
+
+## Available Workflows
+
+### `briefing.yaml` - Market Briefing with Approval
+
+Generates a market briefing and sends to WhatsApp with an approval gate.
+
+**Usage:**
+```bash
+# Run via Lobster CLI
+lobster "workflows.run --file ~/projects/finance-news-clawdbot-skill/workflows/briefing.yaml"
+
+# With custom args
+lobster "workflows.run --file workflows/briefing.yaml --args-json '{\"time\":\"evening\",\"lang\":\"en\"}'"
+```
+
+**Arguments:**
+| Arg | Default | Description |
+|-----|---------|-------------|
+| `time` | `morning` | Briefing type: `morning` or `evening` |
+| `lang` | `de` | Language: `en` or `de` |
+| `channel` | `whatsapp` | Delivery channel: `whatsapp` or `telegram` |
+| `target` | env var | Group name, JID, phone number, or Telegram chat ID |
+| `fast` | `false` | Use fast mode (shorter timeouts) |
+
+**Environment Variables:**
+| Variable | Description |
+|----------|-------------|
+| `FINANCE_NEWS_CHANNEL` | Default channel: `whatsapp` or `telegram` |
+| `FINANCE_NEWS_TARGET` | Default target (group name, phone, chat ID) |
+
+**Examples:**
+```bash
+# WhatsApp group (default)
+lobster "workflows.run --file workflows/briefing.yaml"
+
+# Telegram group
+lobster "workflows.run --file workflows/briefing.yaml --args-json '{\"channel\":\"telegram\",\"target\":\"-1001234567890\"}'"
+
+# WhatsApp DM to phone number
+lobster "workflows.run --file workflows/briefing.yaml --args-json '{\"target\":\"+15551234567\"}'"
+
+# Telegram DM to user
+lobster "workflows.run --file workflows/briefing.yaml --args-json '{\"channel\":\"telegram\",\"target\":\"@username\"}'"
+```
+
+**Flow:**
+1. **Generate** - Runs Docker container to produce briefing JSON
+2. **Approve** - Halts for human review (shows briefing preview)
+3. **Send** - Delivers to channel (WhatsApp/Telegram) after approval
+
+**Requirements:**
+- Docker with `finance-news-briefing` image built
+- `jq` for JSON parsing
+- `clawdbot` CLI for message delivery
+
+## Adding to Lobster Registry
+
+To make these workflows available as named workflows in Lobster:
+
+```typescript
+// In lobster/src/workflows/registry.ts
+export const workflowRegistry = {
+  // ... existing workflows
+  'finance.briefing': {
+    name: 'finance.briefing',
+    description: 'Generate market briefing with approval gate for WhatsApp/Telegram',
+    argsSchema: {
+      type: 'object',
+      properties: {
+        time: { type: 'string', enum: ['morning', 'evening'], default: 'morning' },
+        lang: { type: 'string', enum: ['en', 'de'], default: 'de' },
+        channel: { type: 'string', enum: ['whatsapp', 'telegram'], default: 'whatsapp' },
+        target: { type: 'string', description: 'Group name, JID, phone, or chat ID' },
+        fast: { type: 'boolean', default: false },
+      },
+    },
+    examples: [
+      { args: { time: 'morning', lang: 'de' }, description: 'German morning briefing to WhatsApp' },
+      { args: { channel: 'telegram', target: '-1001234567890' }, description: 'Send to Telegram group' },
+    ],
+    sideEffects: ['message.send'],
+  },
+};
+```
+
+## Why Lobster?
+
+Using Lobster instead of direct cron execution provides:
+
+- **Approval gates** - Review briefing before it's sent
+- **Resumability** - If interrupted, continue from last step
+- **Token efficiency** - One workflow call vs. multiple LLM tool calls
+- **Determinism** - Same inputs = same outputs

--- a/workflows/briefing.yaml
+++ b/workflows/briefing.yaml
@@ -1,0 +1,79 @@
+# Finance Briefing Workflow for Lobster
+# Usage: lobster "workflows.run --file workflows/briefing.yaml --args-json '{\"time\":\"morning\",\"lang\":\"de\"}'"
+#
+# This workflow:
+# 1. Generates a market briefing via Docker
+# 2. Halts for approval before sending
+# 3. Sends to messaging channel after approval
+
+name: finance.briefing
+description: Generate market briefing and send to WhatsApp/Telegram with approval gate
+
+args:
+  time:
+    default: morning
+    description: "Briefing type: morning or evening"
+  lang:
+    default: de
+    description: "Language: en or de"
+  channel:
+    default: "${FINANCE_NEWS_CHANNEL:-whatsapp}"
+    description: "Delivery channel: whatsapp or telegram"
+  target:
+    default: "${FINANCE_NEWS_TARGET}"
+    description: "Target: group name, JID, phone number, or Telegram chat ID (requires FINANCE_NEWS_TARGET env var if not specified)"
+  fast:
+    default: "false"
+    description: "Use fast mode: true or false"
+
+env:
+  SKILL_DIR: "${HOME}/projects/finance-news-clawdbot-skill"
+
+steps:
+  # Generate briefing - outputs JSON with macro_message and portfolio_message
+  - id: generate
+    command: |
+      FAST_FLAG=""
+      if [ "${fast}" = "true" ]; then FAST_FLAG="--fast"; fi
+      docker run --rm \
+        -v "${SKILL_DIR}/config:/app/config:ro" \
+        finance-news-briefing python3 scripts/briefing.py \
+          --time "${time}" \
+          --lang "${lang}" \
+          --json \
+          $FAST_FLAG
+    description: Generate briefing via Docker
+
+  # Approval gate - workflow halts here until user approves
+  - id: approve
+    approval: required
+    command: echo "Review the briefing output above. Approve to send via ${channel} to ${target}."
+    description: Approval gate before message delivery
+
+  # Send macro briefing (market overview)
+  - id: send_macro
+    command: |
+      MSG=$(echo '${generate.stdout}' | jq -r '.macro_message // empty')
+      if [ -n "$MSG" ]; then
+        clawdbot message send \
+          --channel "${channel}" \
+          --target "${target}" \
+          --message "$MSG"
+      else
+        echo "No macro message to send"
+      fi
+    description: Send macro briefing
+
+  # Send portfolio briefing (stock movers)
+  - id: send_portfolio
+    command: |
+      MSG=$(echo '${generate.stdout}' | jq -r '.portfolio_message // empty')
+      if [ -n "$MSG" ]; then
+        clawdbot message send \
+          --channel "${channel}" \
+          --target "${target}" \
+          --message "$MSG"
+      else
+        echo "No portfolio message to send"
+      fi
+    description: Send portfolio briefing


### PR DESCRIPTION
## Summary
- Add Lobster workflow for briefings with approval gate before WhatsApp delivery
- Improve SKILL.md compliance with Claude Skills Best Practices
- Add table of contents to reference docs over 100 lines

## Changes
- **workflows/briefing.yaml** - Lobster workflow with generate → approve → send steps
- **workflows/README.md** - Documentation for workflow usage
- **SKILL.md** - Updated description with trigger phrases, updated file tree
- **docs/PREMIUM_SOURCES.md** - Added TOC (204 lines)
- **docs/EQUITY_SHEET_FIXES.md** - Added TOC (114 lines)

## Lobster Workflow Usage
```bash
# Run with approval before WhatsApp send
lobster "workflows.run --file workflows/briefing.yaml"

# With custom args
lobster "workflows.run --file workflows/briefing.yaml --args-json '{\"time\":\"evening\",\"lang\":\"en\"}'"
```

## Test plan
- [x] Verified briefing runs successfully via Docker
- [ ] Test Lobster workflow execution (requires Lobster CLI)
- [ ] Verify SKILL.md loads correctly in Moltbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)