### PR TITLE
feat: add alerts and earnings cron workflows (#58, #59)

### DIFF
--- a/cron/alerts.sh
+++ b/cron/alerts.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Price Alerts Cron Job (Lobster Workflow)
+# Schedule: 2:00 PM PT / 5:00 PM ET (1 hour after market close)
+#
+# Checks price alerts against current prices including after-hours.
+# Sends triggered alerts and watchlist status to WhatsApp/Telegram.
+
+set -e
+
+export SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export FINANCE_NEWS_TARGET="${FINANCE_NEWS_TARGET:-120363421796203667@g.us}"
+export FINANCE_NEWS_CHANNEL="${FINANCE_NEWS_CHANNEL:-whatsapp}"
+
+echo "[$(date)] Checking price alerts via Lobster..."
+
+lobster run --file "$SKILL_DIR/workflows/alerts-cron.yaml" \
+  --args-json '{"lang":"en"}'
+
+echo "[$(date)] Price alerts check complete."

--- a/cron/earnings.sh
+++ b/cron/earnings.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Earnings Alert Cron Job (Lobster Workflow)
+# Schedule: 6:00 AM PT / 9:00 AM ET (30 min before market open)
+#
+# Sends today's earnings calendar to WhatsApp/Telegram.
+# Alerts users about portfolio stocks reporting today.
+
+set -e
+
+export SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export FINANCE_NEWS_TARGET="${FINANCE_NEWS_TARGET:-120363421796203667@g.us}"
+export FINANCE_NEWS_CHANNEL="${FINANCE_NEWS_CHANNEL:-whatsapp}"
+
+echo "[$(date)] Checking today's earnings via Lobster..."
+
+lobster run --file "$SKILL_DIR/workflows/earnings-cron.yaml" \
+  --args-json '{"lang":"en"}'
+
+echo "[$(date)] Earnings alert complete."

--- a/scripts/alerts.py
+++ b/scripts/alerts.py
@@ -326,28 +326,55 @@ def cmd_check(args) -> None:
     if args.json:
         print(json.dumps({"triggered": triggered, "watching": watching}, indent=2))
         return
-    
+
+    # Translations
+    lang = getattr(args, 'lang', 'en')
+    if lang == "de":
+        labels = {
+            "title": "PREISWARNUNGEN",
+            "in_zone": "IN KAUFZONE",
+            "buy": "KAUFEN!",
+            "target": "Ziel",
+            "watching": "BEOBACHTUNG",
+            "to_target": "noch",
+            "no_data": "Keine Preisdaten für Alerts verfügbar",
+        }
+    else:
+        labels = {
+            "title": "PRICE ALERTS",
+            "in_zone": "IN BUY ZONE",
+            "buy": "BUY SIGNAL",
+            "target": "target",
+            "watching": "WATCHING",
+            "to_target": "to target",
+            "no_data": "No price data available for alerts",
+        }
+
+    # Date header
+    date_str = datetime.now().strftime("%b %d, %Y") if lang == "en" else datetime.now().strftime("%d. %b %Y")
+    print(f"📊 {labels['title']} — {date_str}\n")
+
     # Human-readable output
     if triggered:
-        print("## 🟢 IN KAUFZONE\n")
+        print(f"🟢 {labels['in_zone']}:\n")
         for t in triggered:
             target_str = format_price(t["target_price"], t["currency"])
             current_str = format_price(t["current_price"], t["currency"])
             note = f'\n   "{t["note"]}"' if t.get("note") else ""
             user = f" — {t['set_by']}" if t.get("set_by") else ""
-            print(f"• **{t['ticker']}**: {current_str} (Ziel: {target_str}) ← KAUFEN!{note}{user}")
+            print(f"• {t['ticker']}: {current_str} ({labels['target']}: {target_str}) ← {labels['buy']}{note}{user}")
         print()
-    
+
     if watching:
-        print("## ⏳ WATCHLIST\n")
+        print(f"⏳ {labels['watching']}:\n")
         for w in sorted(watching, key=lambda x: x["pct_from_target"]):
             target_str = format_price(w["target_price"], w["currency"])
             current_str = format_price(w["current_price"], w["currency"])
-            print(f"• {w['ticker']}: {current_str} (Ziel: {target_str}) — noch {w['pct_from_target']:+.1f}%")
+            print(f"• {w['ticker']}: {current_str} ({labels['target']}: {target_str}) — {labels['to_target']} {abs(w['pct_from_target']):.1f}%")
         print()
-    
+
     if not triggered and not watching:
-        print("📭 No price data available for alerts")
+        print(f"📭 {labels['no_data']}")
 
 
 def check_alerts() -> dict:
@@ -451,6 +478,7 @@ def main():
     # check
     check_parser = subparsers.add_parser("check", help="Check alerts against prices")
     check_parser.add_argument("--json", action="store_true", help="JSON output")
+    check_parser.add_argument("--lang", default="en", help="Output language (en, de)")
     
     args = parser.parse_args()
     

--- a/scripts/finance-news
+++ b/scripts/finance-news
@@ -64,13 +64,16 @@ Usage: finance-news <command> [options]
 Commands:
   setup                           Interactive setup wizard
   config                          Show current configuration
-  
+
   briefing [--morning|--evening]  Generate market briefing
   market                          Market overview (indices + headlines)
   portfolio                       News for portfolio stocks
   portfolio-only                  Top gainers/losers from portfolio with news
   news <SYMBOL>                   News for specific ticker
-  
+
+  alerts <subcommand>             Price target alerts (list, set, check, delete, snooze, update)
+  earnings <subcommand>           Earnings calendar (list, check, refresh)
+
   portfolio-list                  List portfolio stocks
   portfolio-add <SYMBOL>          Add stock to portfolio
   portfolio-remove <SYMBOL>       Remove stock from portfolio
@@ -158,7 +161,17 @@ for a in articles:
   portfolio-create)
     "$PYTHON_BIN" "$SCRIPT_DIR/portfolio.py" create
     ;;
-  
+
+  alerts)
+    shift
+    "$PYTHON_BIN" "$SCRIPT_DIR/alerts.py" "$@"
+    ;;
+
+  earnings)
+    shift
+    "$PYTHON_BIN" "$SCRIPT_DIR/earnings.py" "$@"
+    ;;
+
   setup)
     shift
     "$PYTHON_BIN" "$SCRIPT_DIR/setup.py" "$@"

--- a/workflows/alerts-cron.yaml
+++ b/workflows/alerts-cron.yaml
@@ -1,0 +1,45 @@
+# Price Alerts Workflow for Cron (No Approval Gate)
+# Usage: lobster run --file workflows/alerts-cron.yaml --args-json '{"lang":"en"}'
+#
+# Schedule: 2:00 PM PT / 5:00 PM ET (1 hour after market close)
+# Checks price alerts against current prices (including after-hours)
+
+name: finance.alerts.cron
+description: Check price alerts and send triggered alerts to WhatsApp/Telegram
+
+args:
+  lang:
+    default: en
+    description: "Language: en or de"
+  channel:
+    default: "${FINANCE_NEWS_CHANNEL:-whatsapp}"
+    description: "Delivery channel: whatsapp or telegram"
+  target:
+    default: "${FINANCE_NEWS_TARGET}"
+    description: "Target: group name, JID, or chat ID"
+
+steps:
+  # Check alerts against current prices
+  - id: check_alerts
+    command: |
+      SKILL_DIR="${SKILL_DIR:-$HOME/projects/finance-news-clawdbot-skill}"
+      python3 "$SKILL_DIR/scripts/alerts.py" check --lang "${lang}"
+    description: Check price alerts against current prices
+
+  # Send alert message if there's content
+  - id: send_alerts
+    command: |
+      MSG=$(cat)
+      MSG=$(echo "$MSG" | tr -d '\r')
+      # Only send if message has actual content (not just "No price data" message)
+      if echo "$MSG" | grep -q "IN BUY ZONE\|IN KAUFZONE\|WATCHING\|BEOBACHTUNG"; then
+        moltbot message send \
+          --channel "${channel}" \
+          --target "${target}" \
+          --message "$MSG"
+        echo "Sent price alerts to ${channel}"
+      else
+        echo "No triggered alerts or watchlist items to send"
+      fi
+    stdin: $check_alerts.stdout
+    description: Send price alerts to channel

--- a/workflows/earnings-cron.yaml
+++ b/workflows/earnings-cron.yaml
@@ -1,0 +1,45 @@
+# Earnings Alert Workflow for Cron (No Approval Gate)
+# Usage: lobster run --file workflows/earnings-cron.yaml --args-json '{"lang":"en"}'
+#
+# Schedule: 6:00 AM PT / 9:00 AM ET (30 min before market open)
+# Sends today's earnings calendar to WhatsApp/Telegram
+
+name: finance.earnings.cron
+description: Send earnings alerts for today's reports
+
+args:
+  lang:
+    default: en
+    description: "Language: en or de"
+  channel:
+    default: "${FINANCE_NEWS_CHANNEL:-whatsapp}"
+    description: "Delivery channel: whatsapp or telegram"
+  target:
+    default: "${FINANCE_NEWS_TARGET}"
+    description: "Target: group name, JID, or chat ID"
+
+steps:
+  # Check earnings calendar for today and this week
+  - id: check_earnings
+    command: |
+      SKILL_DIR="${SKILL_DIR:-$HOME/projects/finance-news-clawdbot-skill}"
+      python3 "$SKILL_DIR/scripts/earnings.py" check --lang "${lang}"
+    description: Get today's earnings calendar
+
+  # Send earnings alert if there's content
+  - id: send_earnings
+    command: |
+      MSG=$(cat)
+      MSG=$(echo "$MSG" | tr -d '\r')
+      # Only send if there are actual earnings today
+      if echo "$MSG" | grep -q "EARNINGS TODAY\|EARNINGS HEUTE"; then
+        moltbot message send \
+          --channel "${channel}" \
+          --target "${target}" \
+          --message "$MSG"
+        echo "Sent earnings alert to ${channel}"
+      else
+        echo "No earnings today - skipping message"
+      fi
+    stdin: $check_earnings.stdout
+    description: Send earnings alert to channel


### PR DESCRIPTION
## Summary

Implements automated cron jobs for price alerts and earnings calendar that were built in #61 and #60 but never wired into the automation system.

## Price Alerts (`cron/alerts.sh`)
- **Schedule**: 2:00 PM PT / 5:00 PM ET (1 hour after market close)
- Checks alerts against current prices including after-hours
- Only sends message if triggered or watching alerts exist

## Earnings Alerts (`cron/earnings.sh`)
- **Schedule**: 6:00 AM PT / 9:00 AM ET (30 min before market open)
- Shows today's earnings from portfolio stocks
- Only sends message if earnings are scheduled for today

## Files Changed

| File | Change |
|------|--------|
| `scripts/alerts.py` | Add `--lang` flag for multilingual output |
| `scripts/earnings.py` | Add `--json` and `--lang` flags |
| `scripts/finance-news` | Add `alerts` and `earnings` CLI commands |
| `workflows/alerts-cron.yaml` | New Lobster workflow for price alerts |
| `workflows/earnings-cron.yaml` | New Lobster workflow for earnings |
| `cron/alerts.sh` | New cron script for price alerts |
| `cron/earnings.sh` | New cron script for earnings |

## Cron Schedule

```
# Finance News Cron Jobs (PT times)
# Earnings alert:   6:00 AM PT (before market)
# Morning briefing: 6:30 AM PT
# Evening briefing: 1:00 PM PT
# Price alerts:     2:00 PM PT (after market + AH)
```

## Test plan

- [ ] Run `python3 scripts/earnings.py check --lang en` - verify output
- [ ] Run `python3 scripts/earnings.py check --lang de` - verify German
- [ ] Run `bash cron/earnings.sh` - verify WhatsApp message sent
- [ ] Run `bash cron/alerts.sh` - verify price alerts checked

Closes #58, closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)