### PR TITLE
feat: add timestamps to headline output (#22)

### DIFF
--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -869,7 +869,7 @@ def build_briefing_summary(
             title = title or article.get("title", "")
             title = title.strip()
             pub_time = article.get("published_at")
-            age = time_ago(pub_time) if pub_time else ""
+            age = time_ago(pub_time) if isinstance(pub_time, (int, float)) and pub_time else ""
             age_str = f" • {age}" if age else ""
             lines.append(f"{idx}. {title} [{idx}] [{source}]{age_str}")
     else:


### PR DESCRIPTION
## Summary
Add "time ago" timestamps to headline output so users can see how fresh each story is.

Closes #22

## Changes
- Add `time_ago()` helper function to convert Unix timestamps to human-readable format
- Update `build_briefing_summary()` to include article age in headlines

## Output Format

**Before:**
```
1. Fed signals rate cut in March [1] [WSJ]
2. Tech sector leads rally [2] [CNBC]
```

**After:**
```
1. Fed signals rate cut in March [1] [WSJ] • 2h ago
2. Tech sector leads rally [2] [CNBC] • 4h ago
```

## Test plan
- [x] `time_ago()` function tested with various timestamps (30m, 2h, 1d, 3d)
- [x] Python syntax check passes
- [ ] Full briefing test (requires Docker due to NixOS venv issues)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)