### PR TITLE
fix: remove invalid --agent main and disable blocked finanzen.net

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -13,7 +13,7 @@
     },
     "finanzen_net": {
       "name": "Finanzen.net",
-      "enabled": true,
+      "enabled": false,
       "news": "https://www.finanzen.net/rss/news"
     },
     "handelsblatt": {

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -344,7 +344,6 @@ def run_agent_prompt(prompt: str, deadline: float | None = None, session_id: str
         proc_timeout = clamp_timeout(timeout + 10, deadline)
         cmd = [
             'openclaw', 'agent',
-            '--agent', 'main',
             '--session-id', session_id,
             '--message', prompt,
             '--json',
@@ -990,7 +989,6 @@ Use only the following information for the briefing:
         result = subprocess.run(
             [
                 'openclaw', 'agent',
-                '--agent', 'main',
                 '--session-id', 'finance-news-briefing',
                 '--message', prompt,
                 '--json',


### PR DESCRIPTION
## Changes

- Remove `--agent main` args from openclaw agent calls (agent 'main' doesn't exist in gateway config, use default agent instead)
- Disable finanzen_net RSS source (returns 403 due to Akamai WAF blocking all requests)

## Context

When running `--lang de` briefings, translation was failing with 'agent main not found' error because `--agent main` was passed but no agent named 'main' exists in the gateway config. The default agent should be used instead.

finanzen.net blocks all requests (including browser-like User-Agents) with 403 via Akamai WAF, so it's disabled.

## Files Modified
- `config/config.json` - disabled finanzen_net source
- `scripts/summarize.py` - removed `--agent main` from two locations (lines 347, 992)

## Testing
- Run briefing with `--lang de` to verify translation works
- Verify no 403 errors from finanzen.net

Closes #100 (partial - addresses translation and finanzen.net issues)