### PR TITLE
feat: improve skill scores for finance-news-openclaw-skill

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,0 +1,92 @@
+# Finance News — Full Command Reference
+
+## Briefing Generation
+
+```bash
+# Morning briefing (English is default)
+finance-news briefing --morning
+
+# Evening briefing with WhatsApp delivery
+finance-news briefing --evening --send --group "Market Briefing"
+
+# German language option
+finance-news briefing --morning --lang de
+
+# Analysis style (more detailed)
+finance-news briefing --style analysis
+```
+
+## Market Data
+
+```bash
+# Market overview (indices + top headlines)
+finance-news market
+
+# JSON output for processing
+finance-news market --json
+```
+
+## Portfolio Management
+
+```bash
+finance-news portfolio-list                                              # List portfolio
+finance-news portfolio-add NVDA --name "NVIDIA Corporation" --category Tech
+finance-news portfolio-remove TSLA                                       # Remove stock
+finance-news portfolio-import ~/my_stocks.csv                            # Import from CSV
+finance-news portfolio-create                                            # Interactive setup
+```
+
+### Portfolio CSV Format
+
+Location: `~/clawd/skills/finance-news/config/portfolio.csv`
+
+```csv
+symbol,name,category,notes
+AAPL,Apple Inc.,Tech,Core holding
+NVDA,NVIDIA Corporation,Tech,AI play
+MSFT,Microsoft Corporation,Tech,
+```
+
+## Ticker News
+
+```bash
+finance-news news AAPL
+finance-news news TSLA
+```
+
+## Configuration
+
+**Sources:** `~/clawd/skills/finance-news/config/config.json` (legacy fallback: `config/sources.json`) — RSS feeds, market indices by region, and language settings.
+
+## Cron Jobs
+
+### Setup via OpenClaw
+
+```bash
+# Add morning briefing cron job
+openclaw cron add --schedule "30 6 * * 1-5" \
+  --timezone "America/Los_Angeles" \
+  --command "bash ~/clawd/skills/finance-news/cron/morning.sh"
+
+# Add evening briefing cron job
+openclaw cron add --schedule "0 13 * * 1-5" \
+  --timezone "America/Los_Angeles" \
+  --command "bash ~/clawd/skills/finance-news/cron/evening.sh"
+```
+
+Verify cron jobs are registered and test a dry-run:
+
+```bash
+openclaw cron list
+bash ~/clawd/skills/finance-news/cron/morning.sh  # Manual test run
+```
+
+### Manual Cron (crontab)
+
+```cron
+# Morning briefing (6:30 AM PT, weekdays)
+30 6 * * 1-5 bash ~/clawd/skills/finance-news/cron/morning.sh
+
+# Evening briefing (1:00 PM PT, weekdays)
+0 13 * * 1-5 bash ~/clawd/skills/finance-news/cron/evening.sh
+```

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,280 +1,89 @@
 ---
 name: finance-news
-description: Market news briefings with AI summaries and price alerts. Aggregates headlines from US/Europe/Japan markets. Use when: 'stock news', 'market updates', 'morning briefing', 'evening market wrap', 'financial headlines', 'price alerts', 'what happened in the market'. Supports WhatsApp delivery and English/German output. NOT for fundamental analysis or scoring (use equity-research). NOT for raw financial data queries (use openbb).
+description: "Market news briefings with AI summaries and price alerts. Aggregates headlines from US/Europe/Japan markets. Use when: 'stock news', 'market updates', 'morning briefing', 'evening market wrap', 'financial headlines', 'price alerts', 'what happened in the market'. Supports WhatsApp delivery and English/German output. NOT for fundamental analysis or scoring (use equity-research). NOT for raw financial data queries (use openbb)."
 ---
 
 # Finance News Skill
 
-AI-powered market news briefings with configurable language output and automated delivery.
+AI-powered market news briefings with configurable language output and automated delivery via WhatsApp/Telegram.
 
 ## First-Time Setup
 
-Run the interactive setup wizard to configure your sources, delivery channels, and schedule:
+Run the interactive setup wizard:
 
 ```bash
 finance-news setup
 ```
 
-The wizard will guide you through:
-- 📰 **RSS Feeds:** Enable/disable WSJ, Barron's, CNBC, Yahoo, etc.
-- 📊 **Markets:** Choose regions (US, Europe, Japan, Asia)
-- 📤 **Delivery:** Configure WhatsApp/Telegram group
-- 🌐 **Language:** Set default language (English/German)
-- ⏰ **Schedule:** Configure morning/evening cron times
+The wizard configures RSS feeds, markets (US/Europe/Japan/Asia), delivery channels (WhatsApp/Telegram), language (English/German), and cron schedule.
 
-You can also configure specific sections:
+Configure individual sections:
+
 ```bash
 finance-news setup --section feeds     # Just RSS feeds
 finance-news setup --section delivery  # Just delivery channels
 finance-news setup --section schedule  # Just cron schedule
 finance-news setup --reset             # Reset to defaults
+```
+
+Verify setup completed correctly:
+
+```bash
 finance-news config                    # Show current config
+finance-news briefing --morning        # Test a dry-run briefing
 ```
 
 ## Quick Start
 
 ```bash
-# Generate morning briefing
-finance-news briefing --morning
-
-# View market overview
-finance-news market
-
-# Get news for your portfolio
-finance-news portfolio
-
-# Get news for specific stock
-finance-news news AAPL
+finance-news briefing --morning                                  # Morning briefing
+finance-news briefing --evening --send --group "Market Briefing" # Evening + WhatsApp
+finance-news market                                              # Market overview
+finance-news portfolio                                           # Portfolio news
+finance-news news AAPL                                           # Ticker-specific news
 ```
 
-## Features
-
-### 📊 Market Coverage
-- **US Markets:** S&P 500, Dow Jones, NASDAQ
-- **Europe:** DAX, STOXX 50, FTSE 100
-- **Japan:** Nikkei 225
-
-### 📰 News Sources
-- **Premium:** WSJ, Barron's (RSS feeds)
-- **Free:** CNBC, Yahoo Finance, Finnhub
-- **Portfolio:** Ticker-specific news from Yahoo
-
-### 🤖 AI Summaries
-- Gemini-powered analysis
-- Configurable language (English/German)
-- Briefing styles: summary, analysis, headlines
-
-### 📅 Automated Briefings
-- **Morning:** 6:30 AM PT (US market open)
-- **Evening:** 1:00 PM PT (US market close)
-- **Delivery:** WhatsApp (configure group in cron scripts)
-
-## Commands
-
-### Briefing Generation
-
-```bash
-# Morning briefing (English is default)
-finance-news briefing --morning
-
-# Evening briefing with WhatsApp delivery
-finance-news briefing --evening --send --group "Market Briefing"
-
-# German language option
-finance-news briefing --morning --lang de
-
-# Analysis style (more detailed)
-finance-news briefing --style analysis
-```
-
-### Market Data
-
-```bash
-# Market overview (indices + top headlines)
-finance-news market
-
-# JSON output for processing
-finance-news market --json
-```
-
-### Portfolio Management
-
-```bash
-# List portfolio
-finance-news portfolio-list
-
-# Add stock
-finance-news portfolio-add NVDA --name "NVIDIA Corporation" --category Tech
-
-# Remove stock
-finance-news portfolio-remove TSLA
-
-# Import from CSV
-finance-news portfolio-import ~/my_stocks.csv
-
-# Interactive portfolio creation
-finance-news portfolio-create
-```
-
-### Ticker News
-
-```bash
-# News for specific stock
-finance-news news AAPL
-finance-news news TSLA
-```
-
-## Configuration
-
-### Portfolio CSV Format
-
-Location: `~/clawd/skills/finance-news/config/portfolio.csv`
-
-```csv
-symbol,name,category,notes
-AAPL,Apple Inc.,Tech,Core holding
-NVDA,NVIDIA Corporation,Tech,AI play
-MSFT,Microsoft Corporation,Tech,
-```
-
-### Sources Configuration
-
-Location: `~/clawd/skills/finance-news/config/config.json` (legacy fallback: `config/sources.json`)
-
-- RSS feeds for WSJ, Barron's, CNBC, Yahoo
-- Market indices by region
-- Language settings
+See [COMMANDS.md](COMMANDS.md) for the full CLI reference including portfolio management, cron setup, and configuration details.
 
 ## Cron Jobs
 
-### Setup via OpenClaw
-
 ```bash
-# Add morning briefing cron job
+# Add morning briefing (6:30 AM PT, weekdays)
 openclaw cron add --schedule "30 6 * * 1-5" \
   --timezone "America/Los_Angeles" \
   --command "bash ~/clawd/skills/finance-news/cron/morning.sh"
 
-# Add evening briefing cron job
+# Add evening briefing (1:00 PM PT, weekdays)
 openclaw cron add --schedule "0 13 * * 1-5" \
   --timezone "America/Los_Angeles" \
   --command "bash ~/clawd/skills/finance-news/cron/evening.sh"
 ```
 
-### Manual Cron (crontab)
+Verify cron jobs are active:
 
-```cron
-# Morning briefing (6:30 AM PT, weekdays)
-30 6 * * 1-5 bash ~/clawd/skills/finance-news/cron/morning.sh
-
-# Evening briefing (1:00 PM PT, weekdays)
-0 13 * * 1-5 bash ~/clawd/skills/finance-news/cron/evening.sh
-```
-
-## Sample Output
-
-```markdown
-🌅 **Börsen-Morgen-Briefing**
-Dienstag, 21. Januar 2026 | 06:30 Uhr
-
-📊 **Märkte**
-• S&P 500: 5.234 (+0,3%)
-• DAX: 16.890 (-0,1%)
-• Nikkei: 35.678 (+0,5%)
-
-📈 **Dein Portfolio**
-• AAPL $256 (+1,2%) — iPhone-Verkäufe übertreffen Erwartungen
-• NVDA $512 (+3,4%) — KI-Chip-Nachfrage steigt
-
-🔥 **Top Stories**
-• [WSJ] Fed signalisiert mögliche Zinssenkung im März
-• [CNBC] Tech-Sektor führt Rally an
-
-🤖 **Analyse**
-Der S&P zeigt Stärke. Dein Portfolio profitiert von NVDA's 
-Momentum. Fed-Kommentare könnten Volatilität auslösen.
+```bash
+openclaw cron list
+bash ~/clawd/skills/finance-news/cron/morning.sh  # Manual test run
 ```
 
 ## Integration
 
-### With OpenBB (existing skill)
+Combine with OpenBB for detailed quotes before news:
+
 ```bash
-# Get detailed quote, then news
 openbb-quote AAPL && finance-news news AAPL
 ```
 
-### With OpenClaw Agent
-The agent will automatically use this skill when asked about:
-- "What's the market doing?"
-- "News for my portfolio"
-- "Generate morning briefing"
-- "What's happening with AAPL?"
-
-### With Lobster (Workflow Engine)
-
-Run briefings via [Lobster](https://github.com/openclaw/lobster) for approval gates and resumability:
+Run briefings via [Lobster](https://github.com/openclaw/lobster) for approval gates and resumability — see [workflows/README.md](workflows/README.md) for full documentation:
 
 ```bash
-# Run with approval before WhatsApp send
 lobster "workflows.run --file workflows/briefing.yaml"
-
-# With custom args
-lobster "workflows.run --file workflows/briefing.yaml --args-json '{\"time\":\"evening\",\"lang\":\"en\"}'"
 ```
-
-See `workflows/README.md` for full documentation.
-
-## Files
-
-```
-skills/finance-news/
-├── SKILL.md              # This documentation
-├── Dockerfile            # NixOS-compatible container
-├── config/
-│   ├── portfolio.csv     # Your watchlist
-│   ├── config.json       # RSS/API/language configuration
-│   ├── alerts.json       # Price target alerts
-│   └── manual_earnings.json  # Earnings calendar overrides
-├── scripts/
-│   ├── finance-news      # Main CLI
-│   ├── briefing.py       # Briefing generator
-│   ├── fetch_news.py     # News aggregator
-│   ├── portfolio.py      # Portfolio CRUD
-│   ├── summarize.py      # AI summarization
-│   ├── alerts.py         # Price alert management
-│   ├── earnings.py       # Earnings calendar
-│   ├── ranking.py        # Headline ranking
-│   └── stocks.py         # Stock management
-├── workflows/
-│   ├── briefing.yaml     # Lobster workflow with approval gate
-│   └── README.md         # Workflow documentation
-├── cron/
-│   ├── morning.sh        # Morning cron (Docker-based)
-│   └── evening.sh        # Evening cron (Docker-based)
-└── cache/                # 15-minute news cache
-```
-
-## Dependencies
-
-- Python 3.10+
-- `feedparser` (`pip install feedparser`)
-- Gemini CLI (`brew install gemini-cli`)
-- OpenBB (existing `openbb-quote` wrapper)
-- OpenClaw message tool (for WhatsApp delivery)
 
 ## Troubleshooting
 
-### Gemini not working
-```bash
-# Authenticate Gemini
-gemini  # Follow login flow
-```
-
-### RSS feeds timing out
-- Check network connectivity
-- WSJ/Barron's may require subscription cookies for some content
-- Free feeds (CNBC, Yahoo) should always work
-
-### WhatsApp delivery failing
-- Verify WhatsApp group exists and bot has access
-- Check `openclaw doctor` for WhatsApp status
+| Issue | Fix |
+|-------|-----|
+| Gemini not working | Run `gemini` and follow the login flow to authenticate |
+| RSS feeds timing out | Check network; WSJ/Barron's may need subscription cookies; CNBC/Yahoo always work |
+| WhatsApp delivery failing | Verify group exists and bot has access; run `openclaw doctor` |


### PR DESCRIPTION
Hey @kesslerio 👋

Multi-source aggregation across 8 news outlets with Kimi-powered summaries, portfolio-aware briefings, and a Lobster workflow with approval gates before WhatsApp delivery. This is a production-grade financial briefing system, not just a news scraper. The THEORY.md showing the deliberate migration from MiniMax to direct Kimi calls tells me you think carefully about failure boundaries. I'd like to suggest some improvements to the skill file.

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

<img width="1312" height="606" alt="score_card" src="https://github.com/user-attachments/assets/bd935c9b-abff-42e5-8930-fb201754135b" />


> **Note:** The original SKILL.md had unquoted YAML frontmatter (bare single quotes inside the description value), which caused `tessl skill review` to fail validation entirely (10% score). I fixed the quoting first to get a fair baseline of 86% — the table above compares from that corrected baseline.

<details>
<summary>What changed</summary>

**SKILL.md - Content optimization (65% → 100%)**
- **Conciseness**: Removed the Features section (duplicated capabilities already in the description and commands), removed the file tree listing, removed the Dependencies section, and condensed portfolio management commands
- **Workflow clarity**: Added explicit verification steps after first-time setup (`finance-news config` + dry-run briefing) and after cron job registration (`openclaw cron list` + manual test run)
- **Progressive disclosure**: Extracted the full CLI reference, portfolio management, and cron configuration details into a new `COMMANDS.md`, keeping SKILL.md as a focused quick-start overview. Added links to `COMMANDS.md` and `workflows/README.md` for deeper reference
- **Troubleshooting**: Converted from verbose subsections to a compact table format

**SKILL.md - Frontmatter fix**
- Quoted the `description` field value to fix YAML parsing (bare single quotes inside the value caused a parse error)

**New file: COMMANDS.md**
- Full CLI command reference extracted from SKILL.md for progressive disclosure

</details>

Honest disclosure. I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@yogesh-tessl](https://github.com/yogesh-tessl) - if you hit any snags.

Thanks in advance 🙏