### PR TITLE
fix(portfolio): rank evidence quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ docker run --rm -v "$PWD/config:/app/config:ro" \
   --time morning --lang de --json --fast
 ```
 
+If you change ranking, attribution, or source-quality logic, rebuild the image before smoke tests so cron-style runs do not use stale code.
+
 ### Lobster Workflow
 
 ```bash

--- a/config/portfolio_benchmarks.json
+++ b/config/portfolio_benchmarks.json
@@ -86,6 +86,7 @@
       "Bloomberg",
       "CNBC",
       "MarketWatch",
+      "Yahoo Finance",
       "Handelsblatt",
       "Tagesschau",
       "ZEIT"
@@ -97,18 +98,34 @@
       "bloomberg.com",
       "cnbc.com",
       "marketwatch.com",
+      "finance.yahoo.com",
       "handelsblatt.com",
       "tagesschau.de",
       "zeit.de"
     ],
     "blocked_domains": [
-      "finance.yahoo.com",
-      "yahoo.com",
       "fool.com",
       "benzinga.com",
       "zacks.com",
       "investorplace.com",
       "seekingalpha.com"
-    ]
+    ],
+    "quality_scoring": {
+      "minimum_score": 1.1,
+      "allowed_source_bonus": 0.5,
+      "catalyst_bonus": 1.2,
+      "recency_max_bonus": 0.4,
+      "recency_half_life_hours": 24,
+      "low_value_template_penalty": 1.5,
+      "low_value_template_patterns": [
+        "which is the better value stock",
+        "which stock is the better value option",
+        "which stock is better value",
+        "vs\\.",
+        "\\bvs\\b",
+        "outpacing .* peers",
+        "here'?s\\s+what\\s+you\\s+should\\s+know"
+      ]
+    }
   }
 }

--- a/docs/plans/2026-05-05-001-fix-portfolio-headline-quality-ranking-plan.md
+++ b/docs/plans/2026-05-05-001-fix-portfolio-headline-quality-ranking-plan.md
@@ -1,0 +1,208 @@
+---
+title: "fix: Improve portfolio headline quality ranking"
+type: fix
+status: active
+date: 2026-05-05
+---
+
+# fix: Improve portfolio headline quality ranking
+
+## Summary
+
+Reduce low-value portfolio article picks (for example, repetitive "X vs Y value stock" templates) by adding deterministic quality scoring and configurable pattern penalties while keeping Yahoo enabled as a source.
+
+---
+
+## Problem Frame
+
+Morning portfolio output can surface weak templated articles even when they add little catalyst value. Current portfolio evidence selection stops at the first passing item instead of ranking all candidates by quality.
+
+---
+
+## Requirements
+
+- R1. Keep Yahoo available as a source; do not globally block the domain.
+- R2. Demote templated low-information headlines (for example, "which stock is better value", "X vs Y") deterministically.
+- R3. Select the best available per-ticker article using ranked quality signals instead of first-match behavior.
+- R4. Keep behavior configurable via JSON, not hard-coded-only thresholds.
+- R5. Add regression tests proving low-value templates are filtered/demoted and higher-value catalyst stories win.
+
+---
+
+## Scope Boundaries
+
+- Do not redesign macro headline ranking architecture.
+- Do not change cron scheduling or delivery transport behavior in this plan.
+- Do not remove Yahoo from feed configuration.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/portfolio_attribution.py` currently uses `_is_generic_article`, `_has_catalyst`, and `evidence_for_articles(...)` with first-match selection.
+- `scripts/ranking.py` already has deterministic score composition and is suitable as a reference style for weighted scoring.
+- `config/portfolio_benchmarks.json` controls source allow/block policy and should hold quality configuration.
+
+### Institutional Learnings
+
+- Existing tests already codify quality guardrails for portfolio evidence and should be extended in place.
+
+### External References
+
+- None required; repo-local behavior and fixtures are sufficient.
+
+---
+
+## Key Technical Decisions
+
+- Add a two-stage deterministic portfolio evidence selector:
+  1. Eligibility gate (title/source/domain/basic catalyst checks)
+  2. Candidate scoring/ranking (quality score) and choose highest score
+- Move low-value title-template controls into `config/portfolio_benchmarks.json` so tuning does not require code edits.
+- Keep Yahoo allowed, but apply the same template penalties and quality threshold rules as other sources.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should Yahoo be removed to avoid weak content? No; keep Yahoo and demote low-value templates via scoring and thresholds.
+
+### Deferred to Implementation
+
+- Exact penalty weights and minimum score cutoff values after test calibration.
+
+---
+
+## Implementation Units
+
+- U1. **Add Configurable Portfolio Evidence Quality Signals**
+
+**Goal:** Introduce config keys for low-value template patterns, source/domain bonuses, and minimum evidence score.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `config/portfolio_benchmarks.json`
+- Test: `tests/test_portfolio_attribution.py`
+
+**Approach:**
+- Add a `quality_scoring` subsection under `source_quality` with:
+  - template penalty patterns (`vs`, `better value stock`, `outpacing peers`, etc.)
+  - optional source/domain score adjustments
+  - minimum score threshold for acceptance
+- Keep `finance.yahoo.com` out of blocked domains.
+
+**Patterns to follow:**
+- Existing config-driven quality controls in `source_quality`.
+
+**Test scenarios:**
+- Happy path: Yahoo catalyst article with strong signal and no low-value template is accepted by config policy.
+- Edge case: Unknown source with strong catalyst title remains eligible but must pass threshold.
+- Error path: Missing optional scoring keys falls back to safe defaults.
+
+**Verification:**
+- Config loads without schema/runtime errors and tests pass with new keys.
+
+---
+
+- U2. **Implement Ranked Evidence Selection for Portfolio Articles**
+
+**Goal:** Replace first-match evidence selection with deterministic best-candidate ranking.
+
+**Requirements:** R2, R3, R5
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `scripts/portfolio_attribution.py`
+- Test: `tests/test_portfolio_attribution.py`
+
+**Approach:**
+- Add candidate scoring helper(s) for portfolio article quality:
+  - positive signals: catalyst keywords, allowed source/domain, recency
+  - negative signals: low-value template regex/pattern matches
+- Evaluate all eligible articles, rank by score, and return highest-scoring candidate above threshold.
+- Preserve fail-safe behavior: if no candidate passes, return `None` evidence.
+
+**Patterns to follow:**
+- Deterministic scoring composition style in `scripts/ranking.py`.
+
+**Test scenarios:**
+- Happy path: Higher-signal Reuters/Bloomberg article beats weaker candidate.
+- Happy path: High-quality Yahoo article can win when it outranks alternatives.
+- Edge case: Two Yahoo template titles with "X vs Y value stock" are rejected or demoted below threshold.
+- Integration: Mixed article list returns exactly one `Evidence` object from the highest-scoring valid candidate.
+- Error path: Articles with missing link/source/title do not crash and are skipped deterministically.
+
+**Verification:**
+- Portfolio attribution tests pass and selected evidence matches expected top candidate.
+
+---
+
+- U3. **Validate End-to-End Morning Portfolio Output Quality**
+
+**Goal:** Confirm live JSON output no longer elevates low-value template stories after rebuild.
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `README.md`
+
+**Approach:**
+- Rebuild `finance-news-briefing` image after changes.
+- Run morning JSON generation with portfolio CSV mount and inspect `portfolio_message`.
+- Capture source distribution and representative selected titles for sanity-check notes.
+- Document image refresh expectation to prevent stale-image false negatives.
+
+**Patterns to follow:**
+- Existing docker-run based smoke workflow in cron wrappers.
+
+**Test scenarios:**
+- Integration: Morning JSON run completes and emits portfolio section without selected low-value template headlines.
+- Integration: Yahoo remains present in candidate universe; only low-value templates are suppressed.
+
+**Verification:**
+- Smoke output and tests show improved headline mix with Yahoo still available.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Portfolio article selection impacts morning portfolio content quality and downstream localization.
+- **Error propagation:** No change to fail-open behavior; missing evidence continues to produce non-crashing output.
+- **State lifecycle risks:** None; logic is stateless and per-run deterministic.
+- **API surface parity:** JSON output schema remains unchanged.
+- **Integration coverage:** Requires both unit tests and docker-backed smoke checks to avoid stale-image mismatches.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Over-penalizing valid comparative analysis headlines | Keep penalties configurable and test with mixed fixtures |
+| Stale Docker image hides code changes in smoke tests | Force image rebuild before validation |
+| Threshold too strict causing no evidence coverage | Add tests for threshold calibration and adjust defaults conservatively |
+
+---
+
+## Documentation / Operational Notes
+
+- Add a short note in `README.md` that morning smoke validation should rebuild image after ranking/evidence changes.
+
+---
+
+## Sources & References
+
+- Related code: `scripts/portfolio_attribution.py`
+- Related code: `scripts/ranking.py`
+- Related tests: `tests/test_portfolio_attribution.py`
+- Related tests: `tests/test_ranking.py`

--- a/scripts/portfolio_attribution.py
+++ b/scripts/portfolio_attribution.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import json
+import math
+import re
+import time
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -245,15 +249,78 @@ def _is_generic_article(title: str) -> bool:
     return any(pattern in normalized for pattern in GENERIC_ARTICLE_PATTERNS)
 
 
+def _article_timestamp(article: dict) -> float | None:
+    raw = article.get("published_at")
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    if isinstance(raw, str):
+        value = raw.strip()
+        if not value:
+            return None
+        try:
+            return float(value)
+        except ValueError:
+            pass
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def _compile_patterns(raw_patterns: list[object]) -> list[re.Pattern[str]]:
+    compiled: list[re.Pattern[str]] = []
+    for item in raw_patterns:
+        token = str(item).strip()
+        if not token:
+            continue
+        try:
+            compiled.append(re.compile(token, re.IGNORECASE))
+        except re.error:
+            continue
+    return compiled
+
+
+def _template_hit_count(title: str, patterns: list[re.Pattern[str]]) -> int:
+    return sum(1 for pattern in patterns if pattern.search(title))
+
+
+def _recency_bonus(
+    published_at: float | None,
+    *,
+    max_bonus: float,
+    half_life_hours: float,
+) -> float:
+    if published_at is None:
+        return 0.0
+    age_hours = max(0.0, (time.time() - published_at) / 3600.0)
+    if half_life_hours <= 0:
+        return 0.0
+    decay = math.exp(-math.log(2.0) * (age_hours / half_life_hours))
+    return max_bonus * decay
+
+
 def evidence_for_articles(articles: list[dict], config: dict) -> Evidence | None:
     quality = config.get("source_quality", {})
     blocked_domains = [str(item).lower() for item in quality.get("blocked_domains", [])]
     allowed_domains = [str(item).lower() for item in quality.get("allowed_domains", [])]
     allowed_sources = [str(item).lower() for item in quality.get("allowed_sources", [])]
+    scoring = quality.get("quality_scoring", {})
+    min_score = float(scoring.get("minimum_score", 1.0))
+    allowed_source_bonus = float(scoring.get("allowed_source_bonus", 0.5))
+    catalyst_bonus = float(scoring.get("catalyst_bonus", 1.0))
+    recency_max_bonus = float(scoring.get("recency_max_bonus", 0.4))
+    recency_half_life_hours = float(scoring.get("recency_half_life_hours", 24.0))
+    low_value_template_penalty = float(scoring.get("low_value_template_penalty", 1.5))
+    low_value_patterns = _compile_patterns(scoring.get("low_value_template_patterns", []))
+    candidates: list[tuple[float, float, int, Evidence]] = []
 
-    for article in articles:
+    for index, article in enumerate(articles):
         title = str(article.get("title") or "").strip()
-        if not title or _is_generic_article(title) or not _has_catalyst(title):
+        if not title or _is_generic_article(title):
+            continue
+        has_catalyst = _has_catalyst(title)
+        if not has_catalyst:
             continue
         link = str(article.get("link") or "").strip()
         domain = _domain(link)
@@ -262,9 +329,34 @@ def evidence_for_articles(articles: list[dict], config: dict) -> Evidence | None
         source = str(article.get("source") or domain or "Source").strip()
         source_l = source.lower()
         allowed = source_l in allowed_sources or (domain and _domain_matches(domain, allowed_domains))
-        if allowed:
-            return Evidence(title=title, source=source, link=link, confidence="HIGH")
-    return None
+        if not allowed:
+            continue
+        published_at = _article_timestamp(article)
+        score = 0.0
+        score += allowed_source_bonus
+        if has_catalyst:
+            score += catalyst_bonus
+        score += _recency_bonus(
+            published_at,
+            max_bonus=recency_max_bonus,
+            half_life_hours=recency_half_life_hours,
+        )
+        score -= _template_hit_count(title, low_value_patterns) * low_value_template_penalty
+        if score < min_score:
+            continue
+        candidates.append(
+            (
+                score,
+                published_at or 0.0,
+                index,
+                Evidence(title=title, source=source, link=link, confidence="HIGH"),
+            )
+        )
+
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: (-item[0], -item[1], item[2]))
+    return candidates[0][3]
 
 
 def _classification(

--- a/tests/test_portfolio_attribution.py
+++ b/tests/test_portfolio_attribution.py
@@ -19,7 +19,7 @@ def test_load_benchmark_config_has_global_defaults():
 
     assert config["broad_markets"]["default"]["ticker"] == "ACWI"
     assert config["categories"]["Technology"]["ticker"] == "XLK"
-    assert "finance.yahoo.com" in config["source_quality"]["blocked_domains"]
+    assert "finance.yahoo.com" in config["source_quality"]["allowed_domains"]
 
 
 def test_ticker_override_wins_over_category_mapping():
@@ -156,6 +156,63 @@ def test_allowed_source_why_guidance_article_is_evidence():
 
     assert evidence is not None
     assert evidence.confidence == "HIGH"
+
+
+def test_allowed_yahoo_guidance_article_is_evidence():
+    config = load_benchmark_config()
+    articles = [
+        {
+            "title": "Nvidia cuts guidance as data center demand slows",
+            "link": "https://finance.yahoo.com/news/nvidia-cuts-guidance-demand-slows-120000000.html",
+            "source": "Yahoo Finance",
+            "published_at": 1777966800.0,
+        }
+    ]
+
+    evidence = evidence_for_articles(articles, config)
+
+    assert evidence is not None
+    assert evidence.source == "Yahoo Finance"
+
+
+def test_yahoo_value_template_headline_is_not_evidence():
+    config = load_benchmark_config()
+    articles = [
+        {
+            "title": "TKR or HOCPY: Which Is the Better Value Stock Right Now?",
+            "link": "https://finance.yahoo.com/markets/stocks/articles/tkr-hocpy-better-value-stock-154003828.html",
+            "source": "Yahoo Finance",
+            "published_at": 1777966800.0,
+        }
+    ]
+
+    evidence = evidence_for_articles(articles, config)
+
+    assert evidence is None
+
+
+def test_evidence_selection_ranks_candidates_not_first_match():
+    config = load_benchmark_config()
+    articles = [
+        {
+            "title": "Axon (AXON) Stock Outpacing Its Peers This Year?",
+            "link": "https://finance.yahoo.com/news/axon-stock-outpacing-peers-120000000.html",
+            "source": "Yahoo Finance",
+            "published_at": 1777966800.0,
+        },
+        {
+            "title": "Axon raises guidance as enterprise demand accelerates",
+            "link": "https://www.reuters.com/world/us/axon-raises-guidance-2026-05-01/",
+            "source": "Reuters",
+            "published_at": 1777970400.0,
+        },
+    ]
+
+    evidence = evidence_for_articles(articles, config)
+
+    assert evidence is not None
+    assert evidence.source == "Reuters"
+    assert "raises guidance" in evidence.title.lower()
 
 
 def test_allowed_german_catalyst_article_is_evidence():


### PR DESCRIPTION
## What
- add a dated implementation plan for portfolio headline quality ranking
- switch portfolio evidence selection from first-match to deterministic ranked candidate selection
- keep Yahoo enabled for portfolio evidence while penalizing low-value template headlines
- add configurable `source_quality.quality_scoring` controls in `config/portfolio_benchmarks.json`
- extend attribution tests for Yahoo keep-path + template demotion regression coverage
- document Docker image rebuild expectation after ranking/attribution logic changes

## Why
Morning portfolio output was still vulnerable to low-value templated headlines (for example, "which stock is the better value option") whenever those appeared early in per-ticker article lists. We want better article quality without dropping Yahoo entirely.

## Tests
- `uv run pytest -q tests/test_portfolio_attribution.py tests/test_ranking.py --no-cov`
- `uv run ruff check scripts/portfolio_attribution.py tests/test_portfolio_attribution.py`
- deterministic evidence smoke using real morning sample payload:
  - `uv run python - <<'PY' ... build_attributions(...) ... PY`
  - verified `Hoya (7741.T)` now resolves to `NO_CATALYST` instead of selecting the low-value Yahoo value-comparison templates

## Live Smoke Notes
- Full `docker run ... scripts/briefing.py --time morning --lang de --json` could not complete in this environment because the container runtime lacks `ollama`/`gemini` CLIs required by the briefing summary path.
- The selection logic changed in this PR is in `scripts/portfolio_attribution.py` and was validated directly against the real sampled raw portfolio payload.

## AI Assistance
- AI-assisted implementation and review in Codex CLI
- I ran local tests and lint checks listed above
- I understand this code
