### PR TITLE
fix(briefing): stabilize market cron output

### DIFF
--- a/scripts/briefing.py
+++ b/scripts/briefing.py
@@ -95,14 +95,15 @@ def generate_and_send(args):
         timeout = timeout + 5
     result = subprocess.run(
         cmd,
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=None,
         text=True,
         stdin=subprocess.DEVNULL,
         timeout=timeout
     )
     
     if result.returncode != 0:
-        print(f"❌ Briefing generation failed: {result.stderr}", file=sys.stderr)
+        print("❌ Briefing generation failed", file=sys.stderr)
         sys.exit(1)
     
     try:

--- a/scripts/fetch_news.py
+++ b/scripts/fetch_news.py
@@ -926,7 +926,22 @@ def get_portfolio_movers(
     except TimeoutError:
         return {'error': 'Deadline exceeded while fetching portfolio quotes', 'movers': []}
 
-    quotes = fetch_market_data(symbols, timeout=effective_timeout, deadline=deadline)
+    quotes = _fetch_via_yfinance(symbols, timeout=effective_timeout, deadline=deadline)
+    missing = [sym for sym in symbols if sym not in quotes]
+    if missing and (time_left(deadline) is None or time_left(deadline) > 0):
+        fallback_limit = max(
+            max_items * LARGE_PORTFOLIO_FALLBACK_MULTIPLIER,
+            LARGE_PORTFOLIO_FALLBACK_MIN_SYMBOLS,
+        )
+        fallback_symbols = missing[:fallback_limit]
+        fallback_timeout = min(subprocess_timeout, LARGE_PORTFOLIO_FALLBACK_TIMEOUT_CAP_SEC)
+        fallback_quotes = fetch_market_data(
+            fallback_symbols,
+            timeout=fallback_timeout,
+            deadline=deadline,
+            allow_price_fallback=True,
+        )
+        quotes.update(fallback_quotes)
 
     gainers = []
     losers = []

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from difflib import SequenceMatcher
 from pathlib import Path
 
+import urllib.error
 import urllib.parse
 import urllib.request
 from utils import clamp_timeout, compute_deadline, ensure_venv, time_left
@@ -41,6 +42,8 @@ MAX_HEADLINES_IN_PROMPT = 10
 TOP_HEADLINES_COUNT = 5
 DEFAULT_LLM_FALLBACK = ["kimi", "gemini"]
 DEFAULT_OLLAMA_KIMI_MODEL = "kimi-k2.6:cloud"
+DEFAULT_KIMI_API_BASE_URL = "https://api.kimi.com/coding/"
+DEFAULT_KIMI_API_MODEL = "k2p5"
 HEADLINE_SHORTLIST_SIZE = 20
 HEADLINE_MERGE_THRESHOLD = 0.82
 HEADLINE_MAX_AGE_HOURS = 72
@@ -152,6 +155,14 @@ def get_ollama_kimi_model() -> str:
     ).strip()
 
 
+def get_kimi_api_model() -> str:
+    return (
+        os.getenv("FINANCE_NEWS_KIMI_MODEL")
+        or os.getenv("KIMI_MODEL")
+        or DEFAULT_KIMI_API_MODEL
+    ).strip()
+
+
 def ticker_to_name(symbol: str, portfolio_meta: dict | None = None) -> str:
     if not symbol:
         return ""
@@ -202,6 +213,77 @@ def format_price_for_currency(price: float | None, currency: str) -> str:
     symbols = {"USD": "$", "EUR": "€", "GBP": "£", "JPY": "¥", "CHF": "CHF ", "CAD": "C$", "TWD": "NT$"}
     prefix = symbols.get(currency, f"{currency} ")
     return f"{prefix}{price:.2f}"
+
+
+def format_whatsapp_message(message: str) -> str:
+    """Convert common Markdown output into WhatsApp-compatible formatting."""
+    lines = []
+    for line in message.splitlines():
+        heading = re.match(r"^\s{0,3}#{1,6}\s+(.+?)\s*$", line)
+        if heading:
+            lines.append(f"*{heading.group(1).strip()}*")
+        else:
+            lines.append(line)
+
+    text = "\n".join(lines)
+    text = re.sub(r"\*\*([^*\n][^*\n]*?)\*\*", r"*\1*", text)
+    return text
+
+
+def _quote_change_percent(quote: dict) -> float | None:
+    change = quote.get("change_percent")
+    if isinstance(change, (int, float)):
+        return float(change)
+
+    price = quote.get("price")
+    prev_close = quote.get("prev_close")
+    open_price = quote.get("open")
+    if isinstance(price, (int, float)) and isinstance(prev_close, (int, float)) and prev_close:
+        return ((price - prev_close) / prev_close) * 100
+    if isinstance(price, (int, float)) and isinstance(open_price, (int, float)) and open_price:
+        return ((price - open_price) / open_price) * 100
+    return None
+
+
+def extract_portfolio_movers(
+    portfolio_data: dict | None,
+    max_items: int = PORTFOLIO_MOVER_MAX,
+    min_abs_change: float = PORTFOLIO_MOVER_MIN_ABS_CHANGE,
+) -> list[dict]:
+    stocks = portfolio_data.get("stocks", {}) if isinstance(portfolio_data, dict) else {}
+    if not isinstance(stocks, dict):
+        return []
+
+    gainers = []
+    losers = []
+    for symbol, stock_data in stocks.items():
+        if not isinstance(stock_data, dict):
+            continue
+        quote = stock_data.get("quote", {})
+        if not isinstance(quote, dict):
+            continue
+        change_pct = _quote_change_percent(quote)
+        price = quote.get("price")
+        if change_pct is None or not isinstance(price, (int, float)):
+            continue
+
+        item = {"symbol": symbol, "change_pct": change_pct, "price": price}
+        if change_pct >= min_abs_change:
+            gainers.append(item)
+        elif change_pct <= -min_abs_change:
+            losers.append(item)
+
+    gainers.sort(key=lambda x: x["change_pct"], reverse=True)
+    losers.sort(key=lambda x: x["change_pct"])
+
+    max_each = max_items // 2
+    selected = gainers[:max_each] + losers[:max_each]
+    if len(selected) < max_items:
+        remaining = max_items - len(selected)
+        extra = gainers[max_each:] + losers[max_each:]
+        extra.sort(key=lambda x: abs(x["change_pct"]), reverse=True)
+        selected.extend(extra[:remaining])
+    return selected[:max_items]
 
 LANG_PROMPTS = {
     "de": "Output must be in German only.",
@@ -436,15 +518,55 @@ def _run_prompt_command(
     return f"⚠️ {error_label}: {stderr}"
 
 
-def run_ollama_kimi_prompt(prompt: str, deadline: float | None = None, timeout: int = 60) -> str:
-    model = get_ollama_kimi_model()
-    return _run_prompt_command(
-        ["ollama", "run", model],
-        prompt,
-        deadline,
-        timeout,
-        "Kimi briefing error",
+def _kimi_messages_endpoint() -> str:
+    base_url = (os.getenv("KIMI_API_BASE_URL") or DEFAULT_KIMI_API_BASE_URL).strip()
+    return base_url.rstrip("/") + "/v1/messages"
+
+
+def _run_kimi_api_prompt(prompt: str, deadline: float | None, timeout: int) -> str:
+    api_key = (os.getenv("KIMI_API_KEY") or os.getenv("KIMI_API_KEY_WORK") or "").strip()
+    if not api_key:
+        return "⚠️ Kimi briefing error: KIMI_API_KEY or KIMI_API_KEY_WORK not set"
+
+    payload = {
+        "model": get_kimi_api_model(),
+        "max_tokens": int(os.getenv("FINANCE_NEWS_KIMI_MAX_TOKENS", "1200")),
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        _kimi_messages_endpoint(),
+        data=body,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
     )
+
+    try:
+        request_timeout = clamp_timeout(timeout, deadline)
+        with urllib.request.urlopen(req, timeout=request_timeout) as response:
+            response_body = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        error_body = exc.read().decode("utf-8", errors="replace").strip()
+        detail = error_body[:300] if error_body else exc.reason
+        return f"⚠️ Kimi briefing error: HTTP {exc.code}: {detail}"
+    except TimeoutError:
+        return "⚠️ Kimi briefing error: deadline exceeded"
+    except (urllib.error.URLError, OSError) as exc:
+        return f"⚠️ Kimi briefing error: {exc}"
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return f"⚠️ Kimi briefing error: invalid JSON response: {exc}"
+
+    reply_text = _extract_anthropic_text(response_body)
+    if not reply_text:
+        return "⚠️ Kimi briefing error: empty API response"
+    return reply_text
+
+
+def run_ollama_kimi_prompt(prompt: str, deadline: float | None = None, timeout: int = 60) -> str:
+    return _run_kimi_api_prompt(prompt, deadline, timeout)
 
 
 def run_gemini_prompt(prompt: str, deadline: float | None = None, timeout: int = 60) -> str:
@@ -1210,8 +1332,12 @@ def format_market_data(market_data: dict) -> str:
         for symbol, idx in data.get('indices', {}).items():
             if 'data' in idx and idx['data']:
                 price = idx['data'].get('price', 'N/A')
-                change_pct = idx['data'].get('change_percent', 0)
-                lines.append(f"- {idx['name']}: {price} ({change_pct:+.2f}%)")
+                change_pct = idx['data'].get('change_percent')
+                try:
+                    change_text = f"{float(change_pct):+.2f}%"
+                except (TypeError, ValueError):
+                    change_text = "N/A"
+                lines.append(f"- {idx['name']}: {price} ({change_text})")
         lines.append("")
     
     return '\n'.join(lines)
@@ -1742,15 +1868,16 @@ def generate_briefing(args):
     if language == "de" and portfolio_data:
         translate_portfolio_article_items(portfolio_data, deadline=portfolio_deadline)
 
-    movers = []
+    movers = extract_portfolio_movers(portfolio_data)
     try:
-        movers_result = get_portfolio_movers(
-            max_items=PORTFOLIO_MOVER_MAX,
-            min_abs_change=PORTFOLIO_MOVER_MIN_ABS_CHANGE,
-            deadline=portfolio_deadline,
-            subprocess_timeout=subprocess_timeout,
-        )
-        movers = movers_result.get("movers", [])
+        if not movers:
+            movers_result = get_portfolio_movers(
+                max_items=PORTFOLIO_MOVER_MAX,
+                min_abs_change=PORTFOLIO_MOVER_MIN_ABS_CHANGE,
+                deadline=portfolio_deadline,
+                subprocess_timeout=subprocess_timeout,
+            )
+            movers = movers_result.get("movers", [])
     except Exception as exc:
         print(f"⚠️ Skipping portfolio movers: {exc}", file=sys.stderr)
         movers = []
@@ -1942,6 +2069,7 @@ def generate_briefing(args):
     sources_section = format_sources(top_headlines, labels)
     if sources_section:
         macro_output = f"{macro_output}\n{sources_section}\n"
+    macro_output = format_whatsapp_message(macro_output)
 
     # Message 2: Portfolio (if available)
     portfolio_output = ""
@@ -1965,6 +2093,7 @@ def generate_briefing(args):
             benchmark_quotes=benchmark_quotes,
             benchmark_config=benchmark_config,
         )
+        portfolio_output = format_whatsapp_message(portfolio_output)
         
     write_debug_once()
 

--- a/tests/test_fetch_news.py
+++ b/tests/test_fetch_news.py
@@ -7,7 +7,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 import json
 import pytest
 from unittest.mock import Mock, patch, MagicMock
-from fetch_news import fetch_market_data, fetch_rss, _get_best_feed_url, get_large_portfolio_news
+from fetch_news import fetch_market_data, fetch_rss, _get_best_feed_url, get_large_portfolio_news, get_portfolio_movers
 from utils import clamp_timeout, compute_deadline
 
 
@@ -173,6 +173,33 @@ def test_get_large_portfolio_news_respects_top_movers_count(monkeypatch):
 
     assert result["meta"]["top_movers_count"] == 2
     assert len(result["stocks"]) == 2
+
+
+def test_get_portfolio_movers_uses_batch_quotes_before_limited_fallback(monkeypatch):
+    symbols = [f"SYM{i}" for i in range(30)]
+    monkeypatch.setattr("fetch_news.get_portfolio_symbols", lambda: symbols)
+    monkeypatch.setattr(
+        "fetch_news._fetch_via_yfinance",
+        lambda *_a, **_k: {
+            "SYM0": {"change_percent": 3.0, "price": 103.0, "prev_close": 100.0},
+            "SYM1": {"change_percent": -2.0, "price": 98.0, "prev_close": 100.0},
+        },
+    )
+    fallback_calls = []
+
+    def fake_fetch_market_data(fallback_symbols, **_kwargs):
+        fallback_calls.append(list(fallback_symbols))
+        return {
+            "SYM2": {"change_percent": 1.5, "price": 101.5, "prev_close": 100.0},
+            "SYM3": {"change_percent": -1.2, "price": 98.8, "prev_close": 100.0},
+        }
+
+    monkeypatch.setattr("fetch_news.fetch_market_data", fake_fetch_market_data)
+
+    result = get_portfolio_movers(max_items=4, min_abs_change=1.0, subprocess_timeout=30)
+
+    assert fallback_calls == [symbols[2:22]]
+    assert [item["symbol"] for item in result["movers"]] == ["SYM0", "SYM2", "SYM1", "SYM3"]
 
 
 def test_fetch_market_data_openbb_missing_warns_once(monkeypatch, capsys):

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -17,6 +17,8 @@ from summarize import (
     build_watchpoints_data,
     classify_move_type,
     detect_sector_clusters,
+    extract_portfolio_movers,
+    format_market_data,
     format_symbol_display,
     format_watchpoints,
     get_index_change,
@@ -43,6 +45,104 @@ class _FakeUrlopenResponse:
 
     def __exit__(self, exc_type, exc, tb):
         return False
+
+
+def test_format_market_data_handles_non_numeric_change_percent():
+    market_data = {
+        "markets": {
+            "us": {
+                "name": "US",
+                "indices": {
+                    "^GSPC": {
+                        "name": "S&P 500",
+                        "data": {"price": 7136, "change_percent": "N/A"},
+                    },
+                    "^IXIC": {
+                        "name": "Nasdaq",
+                        "data": {"price": 22450, "change_percent": None},
+                    },
+                },
+            }
+        }
+    }
+
+    result = format_market_data(market_data)
+
+    assert "- S&P 500: 7136 (N/A)" in result
+    assert "- Nasdaq: 22450 (N/A)" in result
+
+
+def test_run_ollama_kimi_prompt_calls_kimi_api(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout):
+        captured["url"] = req.full_url
+        captured["timeout"] = timeout
+        captured["headers"] = dict(req.header_items())
+        captured["payload"] = json.loads(req.data.decode("utf-8"))
+        return _FakeUrlopenResponse({"content": [{"type": "text", "text": "Kimi response"}]})
+
+    monkeypatch.setenv("KIMI_API_KEY", "test-key")
+    monkeypatch.setenv("KIMI_API_BASE_URL", "https://api.kimi.test/coding/")
+    monkeypatch.setenv("FINANCE_NEWS_KIMI_MODEL", "k2p5-test")
+    monkeypatch.setattr(summarize.urllib.request, "urlopen", fake_urlopen)
+
+    result = summarize.run_ollama_kimi_prompt("Write a briefing", deadline=None, timeout=45)
+
+    assert result == "Kimi response"
+    assert captured["url"] == "https://api.kimi.test/coding/v1/messages"
+    assert captured["timeout"] == 45
+    assert captured["headers"]["Authorization"] == "Bearer test-key"
+    assert captured["payload"]["model"] == "k2p5-test"
+    assert captured["payload"]["messages"] == [{"role": "user", "content": "Write a briefing"}]
+
+
+def test_run_ollama_kimi_prompt_requires_kimi_key(monkeypatch):
+    monkeypatch.delenv("KIMI_API_KEY", raising=False)
+    monkeypatch.delenv("KIMI_API_KEY_WORK", raising=False)
+
+    result = summarize.run_ollama_kimi_prompt("Write a briefing", deadline=None, timeout=45)
+
+    assert result == "⚠️ Kimi briefing error: KIMI_API_KEY or KIMI_API_KEY_WORK not set"
+
+
+def test_extract_portfolio_movers_reuses_existing_quotes():
+    portfolio_data = {
+        "stocks": {
+            "AAA": {"quote": {"price": 105.0, "prev_close": 100.0}},
+            "BBB": {"quote": {"price": 96.0, "prev_close": 100.0}},
+            "CCC": {"quote": {"price": 101.5, "change_percent": 1.5}},
+            "DDD": {"quote": {"price": 100.2, "prev_close": 100.0}},
+        }
+    }
+
+    movers = extract_portfolio_movers(portfolio_data, max_items=3, min_abs_change=1.0)
+
+    assert movers == [
+        {"symbol": "AAA", "change_pct": 5.0, "price": 105.0},
+        {"symbol": "BBB", "change_pct": -4.0, "price": 96.0},
+        {"symbol": "CCC", "change_pct": 1.5, "price": 101.5},
+    ]
+
+
+def test_format_whatsapp_message_replaces_markdown_headings_and_bold():
+    message = "\n".join([
+        "🌆 **Börsen Abend-Briefing**",
+        "### Märkte",
+        "Alles ruhig.",
+        "## Quellen",
+        "[1] https://example.com",
+    ])
+
+    formatted = summarize.format_whatsapp_message(message)
+
+    assert formatted.splitlines() == [
+        "🌆 *Börsen Abend-Briefing*",
+        "*Märkte*",
+        "Alles ruhig.",
+        "*Quellen*",
+        "[1] https://example.com",
+    ]
 
 
 def test_translate_via_ollama_kimi_parses_markdown_json(monkeypatch):


### PR DESCRIPTION
## What
- Route the Kimi briefing writer through the configured HTTP API instead of shelling out to unavailable CLIs in Docker.
- Make market/portfolio quote handling tolerate degraded quote payloads and reuse already-fetched portfolio quotes.
- Convert delivered briefing text to WhatsApp-compatible bold formatting instead of Markdown headings.
- Stream summarizer stderr through `briefing.py` so cron runs expose progress diagnostics.

## Why
Market briefing cron runs were failing or falling back because the container did not have `ollama`/`gemini`, quote data could contain non-numeric values, and large portfolio mover scans duplicated slow quote work. WhatsApp also rendered `##`/`###` literally.

## Tests
- `FINANCE_NEWS_VENV_BOOTSTRAPPED=1 LD_LIBRARY_PATH=/nix/store/ihpdbhy4rfxaixiamyb588zfc3vj19al-gcc-15.2.0-lib/lib python3 -m pytest -q -o addopts='' tests/test_summarize.py tests/test_fetch_news.py -k 'whatsapp_message or run_ollama_kimi_prompt or non_numeric_change_percent or extract_portfolio_movers or get_portfolio_movers_uses_batch_quotes_before_limited_fallback or get_large_portfolio_news'`
- `python3 - <<'PY' ... compile scripts/briefing.py scripts/summarize.py scripts/fetch_news.py tests/test_summarize.py tests/test_fetch_news.py ... PY`
- `docker build -t finance-news-briefing:latest .`
- Direct cron wrapper checks for `evening-market`, `morning-finance`, and `morning-portfolio` via `/home/art/projects/lobster-workflows/scripts/cron/run-job.sh`.
- Manual OpenClaw rerun of `Evening Market Briefing` delivered successfully.

## AI Assistance
Implemented and verified with Codex.
