### PR TITLE
chore(llm): route fallbacks through agy

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ finance-news briefing --morning --lang de --fast --deadline 300
 | `OLLAMA_KIMI_MODEL` | Secondary override for the Ollama Kimi model | `kimi-k2.6:cloud` |
 | `SKILL_DIR` | Path to skill directory (for Lobster) | `$HOME/projects/finance-news-openclaw-skill` |
 
-LLM generation defaults to `ollama run kimi-k2.6:cloud <prompt>` and falls back to `gemini -p <prompt>`.
+LLM generation defaults to `ollama run kimi-k2.6:cloud <prompt>` and falls back to `AI_MODEL=gemini-3.5-flash-medium agy -p <prompt>`. Deep research uses `gemini-3.5-flash-high` by default. Override with `FINANCE_NEWS_AGY_MODEL` or `AGY_MODEL`.
 
 ## Installation
 

--- a/scripts/research.py
+++ b/scripts/research.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Research Module - Deep research using Ollama Kimi with Gemini CLI fallback.
+Research Module - Deep research using Ollama Kimi with Agy CLI fallback.
 Crawls articles, finds correlations, researches companies.
 Outputs research_report.md for later analysis.
 """
@@ -22,6 +22,7 @@ SCRIPT_DIR = Path(__file__).parent
 CONFIG_DIR = SCRIPT_DIR.parent / "config"
 OUTPUT_DIR = SCRIPT_DIR.parent / "research"
 DEFAULT_OLLAMA_KIMI_MODEL = "kimi-k2.6:cloud"
+DEFAULT_AGY_MODEL = "gemini-3.5-flash-high"
 
 
 ensure_venv()
@@ -89,6 +90,14 @@ def get_ollama_kimi_model() -> str:
     ).strip()
 
 
+def get_agy_model(default: str = DEFAULT_AGY_MODEL) -> str:
+    return (
+        os.getenv("FINANCE_NEWS_AGY_MODEL")
+        or os.getenv("AGY_MODEL")
+        or default
+    ).strip()
+
+
 def ollama_available() -> bool:
     return shutil.which('ollama') is not None
 
@@ -97,8 +106,8 @@ def kimi_available() -> bool:
     return ollama_available()
 
 
-def gemini_available() -> bool:
-    return shutil.which('gemini') is not None
+def agy_available() -> bool:
+    return shutil.which('agy') is not None
 
 
 def build_research_prompt(content: str, focus_areas: list | None = None) -> str:
@@ -144,13 +153,20 @@ Deliver a substantial report (500-800 words).
     return prompt
 
 
-def run_prompt_command(command: list[str], prompt: str, timeout: int, error_label: str) -> str:
+def run_prompt_command(
+    command: list[str],
+    prompt: str,
+    timeout: int,
+    error_label: str,
+    env: dict[str, str] | None = None,
+) -> str:
     try:
         result = subprocess.run(
             [*command, prompt],
             capture_output=True,
             text=True,
-            timeout=timeout
+            timeout=timeout,
+            env={**os.environ, **env} if env else None,
         )
 
         if result.returncode == 0:
@@ -175,9 +191,15 @@ def research_with_kimi(content: str, focus_areas: list | None = None) -> str:
 
 
 def research_with_gemini(content: str, focus_areas: list | None = None) -> str:
-    """Perform deep research using Gemini CLI fallback."""
+    """Perform deep research using Agy CLI fallback."""
     prompt = build_research_prompt(content, focus_areas)
-    return run_prompt_command(["gemini", "-p"], prompt, 120, "Gemini research error")
+    return run_prompt_command(
+        ["agy", "-p"],
+        prompt,
+        120,
+        "Agy research error",
+        {"AI_MODEL": get_agy_model()},
+    )
 
 
 def format_raw_data_report(market_data: dict, portfolio_data: dict) -> str:
@@ -205,7 +227,7 @@ def generate_research_content(market_data: dict, portfolio_data: dict, focus_are
                 'report': report,
                 'source': 'kimi'
             }
-    if gemini_available():
+    if agy_available():
         report = research_with_gemini(raw_report, focus_areas)
         if not report.startswith("⚠️"):
             return {
@@ -263,7 +285,7 @@ def generate_research_report(args):
     if source == 'kimi':
         print("🔬 Running deep research with Ollama Kimi...", file=sys.stderr)
     elif source == 'gemini':
-        print("🔬 Running deep research with Gemini CLI...", file=sys.stderr)
+        print("🔬 Running deep research with Agy CLI...", file=sys.stderr)
     else:
         print("🧾 LLM research unavailable; using raw data report", file=sys.stderr)
     

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 News Summarizer - Generate market briefings in configurable language.
-Uses local Ollama Kimi for briefing generation with Gemini CLI fallback.
+Uses local Ollama Kimi for briefing generation with Agy CLI fallback.
 """
 
 import argparse
@@ -43,6 +43,7 @@ MAX_HEADLINES_IN_PROMPT = 10
 TOP_HEADLINES_COUNT = 5
 DEFAULT_LLM_FALLBACK = ["kimi", "gemini"]
 DEFAULT_OLLAMA_KIMI_MODEL = "kimi-k2.6:cloud"
+DEFAULT_AGY_MODEL = "gemini-3.5-flash-medium"
 DEFAULT_KIMI_API_BASE_URL = "https://api.kimi.com/coding/"
 DEFAULT_KIMI_API_MODEL = "k2p5"
 HEADLINE_SHORTLIST_SIZE = 20
@@ -161,6 +162,14 @@ def get_kimi_api_model() -> str:
         os.getenv("FINANCE_NEWS_KIMI_MODEL")
         or os.getenv("KIMI_MODEL")
         or DEFAULT_KIMI_API_MODEL
+    ).strip()
+
+
+def get_agy_model(default: str = DEFAULT_AGY_MODEL) -> str:
+    return (
+        os.getenv("FINANCE_NEWS_AGY_MODEL")
+        or os.getenv("AGY_MODEL")
+        or default
     ).strip()
 
 
@@ -514,6 +523,7 @@ def _run_prompt_command(
     deadline: float | None,
     timeout: int,
     error_label: str,
+    env: dict[str, str] | None = None,
 ) -> str:
     try:
         proc_timeout = clamp_timeout(timeout, deadline)
@@ -521,7 +531,8 @@ def _run_prompt_command(
             [*command, prompt],
             capture_output=True,
             text=True,
-            timeout=proc_timeout
+            timeout=proc_timeout,
+            env={**os.environ, **env} if env else None,
         )
     except subprocess.TimeoutExpired:
         return f"⚠️ {error_label}: timeout"
@@ -590,13 +601,14 @@ def run_ollama_kimi_prompt(prompt: str, deadline: float | None = None, timeout: 
     return _run_kimi_api_prompt(prompt, deadline, timeout)
 
 
-def run_gemini_prompt(prompt: str, deadline: float | None = None, timeout: int = 60) -> str:
+def run_agy_prompt(prompt: str, deadline: float | None = None, timeout: int = 60) -> str:
     return _run_prompt_command(
-        ["gemini", "-p"],
+        ["agy", "-p"],
         prompt,
         deadline,
         timeout,
-        "Gemini briefing error",
+        "Agy briefing error",
+        env={"AI_MODEL": get_agy_model()},
     )
 
 
@@ -606,14 +618,14 @@ def run_agent_prompt(
     session_id: str = "finance-news-headlines",
     timeout: int = 45,
 ) -> str:
-    """Run a prompt through Ollama Kimi, then Gemini CLI if Kimi fails."""
+    """Run a prompt through Ollama Kimi, then Agy CLI if Kimi fails."""
     del session_id
     reply = run_ollama_kimi_prompt(prompt, deadline=deadline, timeout=timeout)
     if not reply.startswith("⚠️"):
         return reply
 
-    print(f"  ↳ {reply}; falling back to gemini -p", file=sys.stderr)
-    return run_gemini_prompt(prompt, deadline=deadline, timeout=timeout)
+    print(f"  ↳ {reply}; falling back to agy -p", file=sys.stderr)
+    return run_agy_prompt(prompt, deadline=deadline, timeout=timeout)
 
 
 def normalize_title(title: str) -> str:
@@ -1132,7 +1144,7 @@ def translate_headlines(
 ) -> tuple[list[str], bool]:
     """Translate headlines to German using LLM.
 
-    Uses local Ollama Kimi first, then Gemini CLI.
+    Uses local Ollama Kimi first, then Agy CLI.
     Returns (translated_titles, success) or (original_titles, False) on failure.
     """
     if not titles:
@@ -1144,10 +1156,10 @@ def translate_headlines(
         print("  ↳ ✅ Translation successful via Ollama Kimi", file=sys.stderr)
         return translated, True
 
-    print("  ↳ Ollama Kimi failed, falling back to gemini -p", file=sys.stderr)
-    translated, success = translate_via_gemini_cli(titles, deadline=deadline)
+    print("  ↳ Ollama Kimi failed, falling back to agy -p", file=sys.stderr)
+    translated, success = translate_via_agy_cli(titles, deadline=deadline)
     if success:
-        print("  ↳ ✅ Translation successful via Gemini CLI", file=sys.stderr)
+        print("  ↳ ✅ Translation successful via Agy CLI", file=sys.stderr)
         return translated, True
 
     return titles, False
@@ -1217,11 +1229,11 @@ def translate_via_ollama_kimi(
     return _translate_via_prompt_runner(titles, deadline, run_ollama_kimi_prompt, "Ollama Kimi")
 
 
-def translate_via_gemini_cli(
+def translate_via_agy_cli(
     titles: list[str],
     deadline: float | None,
 ) -> tuple[list[str], bool]:
-    return _translate_via_prompt_runner(titles, deadline, run_gemini_prompt, "Gemini CLI")
+    return _translate_via_prompt_runner(titles, deadline, run_agy_prompt, "Agy CLI")
 
 
 def translate_headline_items(headlines: list[dict], deadline: float | None) -> bool:
@@ -1336,9 +1348,9 @@ def summarize_with_gemini(
     style: str = "briefing",
     deadline: float | None = None,
 ) -> str:
-    """Generate AI summary using Gemini CLI fallback."""
+    """Generate AI summary using Agy CLI fallback."""
     prompt = _build_summary_prompt(content, language, style)
-    reply_text = run_gemini_prompt(prompt, deadline=deadline, timeout=60)
+    reply_text = run_agy_prompt(prompt, deadline=deadline, timeout=60)
     if reply_text.startswith("⚠️"):
         return reply_text
     return reply_text + format_disclaimer(language)
@@ -1888,7 +1900,7 @@ def generate_briefing(args):
     )
 
     # Headline selection uses deterministic ranking first; the LLM path uses
-    # local Ollama Kimi with Gemini CLI fallback.
+    # local Ollama Kimi with Agy CLI fallback.
 
     shortlist_by_lang = config.get("headline_shortlist_size_by_lang", {})
     shortlist_size = HEADLINE_SHORTLIST_SIZE

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -15,7 +15,7 @@ from research import (
     format_market_data,
     format_portfolio_news,
     format_raw_data_report,
-    gemini_available,
+    agy_available,
     generate_research_content,
     kimi_available,
     ollama_available,
@@ -230,10 +230,10 @@ class TestProviderAvailability:
         with patch("shutil.which", return_value="/usr/local/bin/ollama"):
             assert kimi_available() is True
 
-    def test_gemini_available_checks_gemini(self):
-        """Gemini fallback availability checks gemini CLI."""
-        with patch("shutil.which", return_value="/usr/local/bin/gemini"):
-            assert gemini_available() is True
+    def test_agy_available_checks_agy(self):
+        """Agy fallback availability checks agy CLI."""
+        with patch("shutil.which", return_value="/usr/local/bin/agy"):
+            assert agy_available() is True
 
 
 class TestResearchWithKimi:
@@ -298,15 +298,16 @@ class TestResearchWithKimi:
 class TestResearchWithGemini:
     """Tests for research_with_gemini()."""
 
-    def test_research_with_gemini_uses_gemini_cli(self):
-        """Gemini fallback uses gemini -p."""
+    def test_research_with_gemini_uses_agy_cli(self):
+        """Fallback uses agy -p with high-thinking model by default."""
         mock_result = Mock()
         mock_result.returncode = 0
-        mock_result.stdout = "Gemini report"
+        mock_result.stdout = "Agy report"
 
         with patch("subprocess.run", return_value=mock_result) as mock_run:
-            assert research_with_gemini("content") == "Gemini report"
-            assert mock_run.call_args[0][0][:2] == ["gemini", "-p"]
+            assert research_with_gemini("content") == "Agy report"
+            assert mock_run.call_args[0][0][:2] == ["agy", "-p"]
+            assert mock_run.call_args.kwargs["env"]["AI_MODEL"] == "gemini-3.5-flash-high"
 
 
 class TestFormatRawDataReport:
@@ -358,7 +359,7 @@ class TestGenerateResearchContent:
         """Use Gemini when Kimi is unavailable or fails."""
         with patch("research.kimi_available", return_value=True):
             with patch("research.research_with_kimi", return_value="⚠️ Kimi research error: timeout"):
-                with patch("research.gemini_available", return_value=True):
+                with patch("research.agy_available", return_value=True):
                     with patch("research.research_with_gemini", return_value="Gemini report") as mock_gemini:
                         result = generate_research_content(sample_market_data, sample_portfolio_data)
 
@@ -369,7 +370,7 @@ class TestGenerateResearchContent:
     def test_falls_back_to_raw_report(self, sample_market_data, sample_portfolio_data):
         """Fall back to raw report when LLM providers are unavailable."""
         with patch("research.kimi_available", return_value=False):
-            with patch("research.gemini_available", return_value=False):
+            with patch("research.agy_available", return_value=False):
                 result = generate_research_content(sample_market_data, sample_portfolio_data)
 
             assert "## Market Data" in result["report"]

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from datetime import datetime
+from unittest.mock import Mock
 
 import summarize
 from summarize import (
@@ -166,22 +167,22 @@ def test_translate_headlines_uses_ollama_kimi_first(monkeypatch):
     )
 
     def fail_if_called(*_args, **_kwargs):
-        raise AssertionError("Gemini fallback should not be called when Kimi succeeds")
+        raise AssertionError("Agy fallback should not be called when Kimi succeeds")
 
-    monkeypatch.setattr(summarize, "translate_via_gemini_cli", fail_if_called)
+    monkeypatch.setattr(summarize, "translate_via_agy_cli", fail_if_called)
 
     translated, success = summarize.translate_headlines(["Title"], deadline=None)
     assert success is True
     assert translated == ["Titel"]
 
 
-def test_translate_headlines_falls_back_to_gemini(monkeypatch):
+def test_translate_headlines_falls_back_to_agy(monkeypatch):
     monkeypatch.setattr(
         summarize,
         "translate_via_ollama_kimi",
         lambda titles, deadline: (titles, False),
     )
-    monkeypatch.setattr(summarize, "translate_via_gemini_cli", lambda titles, deadline: (["Titel"], True))
+    monkeypatch.setattr(summarize, "translate_via_agy_cli", lambda titles, deadline: (["Titel"], True))
 
     translated, success = summarize.translate_headlines(["Title"], deadline=None)
     assert success is True
@@ -217,11 +218,23 @@ def test_translate_via_ollama_kimi_length_mismatch(monkeypatch):
     assert translated == ["Title A", "Title B", "Title C"]
 
 
-def test_translate_via_gemini_cli_success(monkeypatch):
-    monkeypatch.setattr(summarize, "run_gemini_prompt", lambda *_a, **_k: '["Titel"]')
-    translated, success = summarize.translate_via_gemini_cli(["Title"], deadline=None)
+def test_translate_via_agy_cli_success(monkeypatch):
+    monkeypatch.setattr(summarize, "run_agy_prompt", lambda *_a, **_k: '["Titel"]')
+    translated, success = summarize.translate_via_agy_cli(["Title"], deadline=None)
     assert success is True
     assert translated == ["Titel"]
+
+
+def test_run_agy_prompt_sets_medium_model(monkeypatch):
+    result = Mock()
+    result.returncode = 0
+    result.stdout = "OK"
+    monkeypatch.setattr(summarize.subprocess, "run", Mock(return_value=result))
+
+    assert summarize.run_agy_prompt("prompt", deadline=None) == "OK"
+    call = summarize.subprocess.run.call_args
+    assert call[0][0][:2] == ["agy", "-p"]
+    assert call.kwargs["env"]["AI_MODEL"] == "gemini-3.5-flash-medium"
 
 
 def test_translate_via_ollama_kimi_empty_list():
@@ -674,9 +687,9 @@ def test_summarize_with_kimi_missing_ollama(monkeypatch):
 
 
 def test_summarize_with_gemini_success(monkeypatch):
-    monkeypatch.setattr(summarize, "run_gemini_prompt", lambda *_a, **_k: "## Analysis\n\nGemini body")
+    monkeypatch.setattr(summarize, "run_agy_prompt", lambda *_a, **_k: "## Analysis\n\nAgy body")
     summary = summarize.summarize_with_gemini("Raw content", language="en", style="analysis", deadline=None)
-    assert "Gemini body" in summary
+    assert "Agy body" in summary
     assert "informational purposes only" in summary
 
 


### PR DESCRIPTION
## What
- Switch finance-news fallback calls from Gemini CLI print mode to `agy -p`.
- Add Agy model-tier defaults: medium for briefing/headline fallback, high for deep research.
- Keep Kimi as the primary route and update tests/docs for the Agy fallback.

## Why
The fallback should use the authenticated Antigravity CLI instead of the removed Gemini CLI path while preserving task-specific model-tier selection through `AI_MODEL`.

## Tests
- `timeout -k5s 30s ./venv/bin/python -m pytest -o addopts='' tests/test_research.py::TestProviderAvailability::test_agy_available_checks_agy tests/test_research.py::TestResearchWithGemini::test_research_with_gemini_uses_agy_cli tests/test_research.py::TestGenerateResearchContent::test_falls_back_to_gemini_when_kimi_fails tests/test_research.py::TestGenerateResearchContent::test_falls_back_to_raw_report tests/test_summarize.py::test_run_agy_prompt_sets_medium_model tests/test_summarize.py::test_translate_via_agy_cli_success tests/test_summarize.py::test_summarize_with_gemini_success -q`
- `git diff --check -- README.md scripts/research.py scripts/summarize.py tests/test_research.py tests/test_summarize.py`
- `/home/art/projects/ai-dotfiles/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## AI Assistance
Implemented and reviewed with AI assistance. Autoreview reported no accepted/actionable findings.