### PR TITLE
feat: migrate finance-news off Kimi/Gemini Cloud to local Qwen + DS4-high (Ollama pause)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,13 @@ RUN pip install --no-cache-dir openbb openbb-yfinance
 # Copy application code
 COPY . .
 
-ENV KIMI_API_KEY=
-ENV KIMI_API_BASE_URL=https://api.kimi.com/coding/
-ENV FINANCE_NEWS_KIMI_MODEL=k2p5
-ENV MINIMAX_CODING_PLAN_API_KEY=
+# Local tailnet LLM routes (kalliope Qwen primary, gx10 DS4 fallback).
+# The bearer token is injected at runtime via `docker run -e KALLIOPE_SERVING_API_KEY`.
+ENV KALLIOPE_SERVING_API_KEY=
+ENV FINANCE_NEWS_QWEN_BASE_URL=http://100.124.155.99:4000/v1
+ENV FINANCE_NEWS_QWEN_MODEL=qwen3.6:35b-a3b
+ENV FINANCE_NEWS_DS4_BASE_URL=http://gx10r-head:8888/v1
+ENV FINANCE_NEWS_DS4_MODEL=deepseek-v4-flash-dspark
 ENV FINANCE_NEWS_SUPPRESS_VENV_WARNING=1
 ENV OPENBB_QUOTE_BIN=/app/scripts/openbb-quote
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,19 @@ finance-news briefing --morning --lang de --fast --deadline 300
 |----------|-------------|---------|
 | `FINANCE_NEWS_TARGET` | Delivery target (WhatsApp JID, group name, or Telegram chat ID) | *Required* |
 | `FINANCE_NEWS_CHANNEL` | Delivery channel | `whatsapp` or `telegram` |
-| `FINANCE_NEWS_OLLAMA_KIMI_MODEL` | Ollama model used for Kimi summaries/research | `kimi-k2.6:cloud` |
-| `OLLAMA_KIMI_MODEL` | Secondary override for the Ollama Kimi model | `kimi-k2.6:cloud` |
+| `KALLIOPE_SERVING_API_KEY` | Bearer token for the local Qwen route (required) | *Required* |
+| `FINANCE_NEWS_QWEN_BASE_URL` | Qwen route base URL | `http://100.124.155.99:4000/v1` |
+| `FINANCE_NEWS_QWEN_MODEL` | Qwen model for summaries/selection/translation | `qwen3.6:35b-a3b` |
+| `FINANCE_NEWS_DS4_BASE_URL` | DS4 route base URL (fallback writer / deep-research primary) | `http://gx10r-head:8888/v1` |
+| `FINANCE_NEWS_DS4_MODEL` | DS4 model | `deepseek-v4-flash-dspark` |
+| `FINANCE_NEWS_DS4_API_KEY` | Optional bearer token for the DS4 route | *(unset)* |
 | `SKILL_DIR` | Path to skill directory (for Lobster) | `$HOME/projects/finance-news-openclaw-skill` |
 
-LLM generation defaults to `ollama run kimi-k2.6:cloud <prompt>` and falls back to `AI_MODEL=gemini-3.5-flash-medium agy -p <prompt>`. Deep research uses `gemini-3.5-flash-high` by default. Override with `FINANCE_NEWS_AGY_MODEL` or `AGY_MODEL`.
+Summaries, headline selection, and translation default to the local **Qwen** route
+(`qwen3.6:35b-a3b` on kalliope) with the local **DS4** route
+(`deepseek-v4-flash-dspark` on gx10) as fallback. Deep research (`research.py`) uses the
+**DS4-high** route as primary with the Qwen route as fallback. All routes are
+OpenAI-compatible tailnet endpoints; there is no cloud fallback.
 
 ## Installation
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -84,6 +84,6 @@ lobster "workflows.run --file workflows/briefing.yaml"
 
 | Issue | Fix |
 |-------|-----|
-| Gemini not working | Run `gemini` and follow the login flow to authenticate |
+| Briefing writer failing | Verify `KALLIOPE_SERVING_API_KEY` is set and the local Qwen route (`http://100.124.155.99:4000/v1`) is reachable; the DS4 route (`http://gx10r-head:8888/v1`) is the fallback |
 | RSS feeds timing out | Check network; WSJ/Barron's may need subscription cookies; CNBC/Yahoo always work |
 | WhatsApp delivery failing | Verify group exists and bot has access; run `openclaw doctor` |

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -1,5 +1,12 @@
 # Theory: Deterministic Kimi Briefing Migration
 
+> **SUPERSEDED (2026-07-22).** This document is retained only as historical rationale
+> for the earlier direct-writer migration. The Kimi/Ollama-Cloud writer described below
+> has since been replaced by the local tailnet routes (kalliope Qwen primary; gx10
+> DeepSeek-V4-Flash fallback; deep research on DS4-high) for the Ollama Cloud pause.
+> The "call the writer directly from the skill" seam still holds; only the model routes
+> changed. See `README.md` for the current routing.
+
 ## Problem
 
 The briefing path is split across two layers that should have different responsibilities. The outer cron and workflow layer should be boring: invoke the container, capture JSON, validate structure, and send it. The writing itself belongs inside `finance-news`, where the prompt, formatting rules, disclaimers, and fallbacks are already defined. Right now the repo still carries briefing-generation paths that depend on MiniMax and `openclaw agent`, which makes the core writing path depend on a second orchestration layer and on model routing outside the skill. That is the wrong failure boundary. If Kimi is the desired writer, the skill should call Kimi directly.

--- a/config/config.json
+++ b/config/config.json
@@ -226,16 +226,16 @@
   },
   "llm": {
     "headline_model_order": [
-      "kimi",
-      "gemini"
+      "qwen",
+      "ds4"
     ],
     "summary_model_order": [
-      "kimi",
-      "gemini"
+      "qwen",
+      "ds4"
     ],
     "translation_model_order": [
-      "kimi",
-      "gemini"
+      "qwen",
+      "ds4"
     ]
   },
   "translations": {

--- a/scripts/briefing.py
+++ b/scripts/briefing.py
@@ -157,8 +157,8 @@ def main():
     parser.add_argument('--deadline', type=int, default=None,
                         help='Overall deadline in seconds')
     parser.add_argument('--llm', action='store_true', help='Force LLM summary for non-briefing styles')
-    parser.add_argument('--model', choices=['kimi', 'gemini'],
-                        default='kimi', help='Summary model override')
+    parser.add_argument('--model', choices=['qwen', 'ds4'],
+                        default='qwen', help='Local writer route override (qwen or ds4)')
     parser.add_argument('--fast', action='store_true',
                         help='Use fast mode (shorter timeouts, fewer items)')
     parser.add_argument('--debug', action='store_true',

--- a/scripts/research.py
+++ b/scripts/research.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-Research Module - Deep research using Ollama Kimi with Agy CLI fallback.
+Research Module - Deep research using the local gx10 DeepSeek-V4-Flash (DS4)
+route, with the local kalliope Qwen route as fallback.
 Crawls articles, finds correlations, researches companies.
 Outputs research_report.md for later analysis.
 """
@@ -8,21 +9,25 @@ Outputs research_report.md for later analysis.
 import argparse
 import json
 import os
-import shutil
-import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
 
-from utils import ensure_venv
+from utils import call_openai_chat, ensure_venv
 
 from fetch_news import PortfolioError, get_market_news, get_portfolio_news
 
 SCRIPT_DIR = Path(__file__).parent
 CONFIG_DIR = SCRIPT_DIR.parent / "config"
 OUTPUT_DIR = SCRIPT_DIR.parent / "research"
-DEFAULT_OLLAMA_KIMI_MODEL = "kimi-k2.6:cloud"
-DEFAULT_AGY_MODEL = "gemini-3.5-flash-high"
+# Deep research is a genuinely complex / materiality task -> DS4-high primary,
+# local Qwen fallback. Both are OpenAI-compatible tailnet routes.
+DEFAULT_DS4_BASE_URL = "http://gx10r-head:8888/v1"
+DEFAULT_DS4_MODEL = "deepseek-v4-flash-dspark"
+DEFAULT_QWEN_BASE_URL = "http://100.124.155.99:4000/v1"
+DEFAULT_QWEN_MODEL = "qwen3.6:35b-a3b"
+RESEARCH_MAX_TOKENS = int(os.getenv("FINANCE_NEWS_RESEARCH_MAX_TOKENS", "2048"))
+RESEARCH_TIMEOUT = int(os.getenv("FINANCE_NEWS_RESEARCH_TIMEOUT", "120"))
 
 
 ensure_venv()
@@ -82,32 +87,28 @@ def format_portfolio_news(portfolio_data: dict) -> str:
     return '\n'.join(lines)
 
 
-def get_ollama_kimi_model() -> str:
+def get_ds4_base_url() -> str:
+    return (os.getenv("FINANCE_NEWS_DS4_BASE_URL") or DEFAULT_DS4_BASE_URL).strip()
+
+
+def get_ds4_model() -> str:
     return (
-        os.getenv("FINANCE_NEWS_OLLAMA_KIMI_MODEL")
-        or os.getenv("OLLAMA_KIMI_MODEL")
-        or DEFAULT_OLLAMA_KIMI_MODEL
+        os.getenv("FINANCE_NEWS_DS4_MODEL")
+        or os.getenv("DS4_MODEL")
+        or DEFAULT_DS4_MODEL
     ).strip()
 
 
-def get_agy_model(default: str = DEFAULT_AGY_MODEL) -> str:
+def get_qwen_base_url() -> str:
+    return (os.getenv("FINANCE_NEWS_QWEN_BASE_URL") or DEFAULT_QWEN_BASE_URL).strip()
+
+
+def get_qwen_model() -> str:
     return (
-        os.getenv("FINANCE_NEWS_AGY_MODEL")
-        or os.getenv("AGY_MODEL")
-        or default
+        os.getenv("FINANCE_NEWS_QWEN_MODEL")
+        or os.getenv("QWEN_MODEL")
+        or DEFAULT_QWEN_MODEL
     ).strip()
-
-
-def ollama_available() -> bool:
-    return shutil.which('ollama') is not None
-
-
-def kimi_available() -> bool:
-    return ollama_available()
-
-
-def agy_available() -> bool:
-    return shutil.which('agy') is not None
 
 
 def build_research_prompt(content: str, focus_areas: list | None = None) -> str:
@@ -153,52 +154,35 @@ Deliver a substantial report (500-800 words).
     return prompt
 
 
-def run_prompt_command(
-    command: list[str],
-    prompt: str,
-    timeout: int,
-    error_label: str,
-    env: dict[str, str] | None = None,
-) -> str:
-    try:
-        result = subprocess.run(
-            [*command, prompt],
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            env={**os.environ, **env} if env else None,
-        )
-
-        if result.returncode == 0:
-            return result.stdout.strip()
-        return f"⚠️ {error_label}: {result.stderr}"
-
-    except subprocess.TimeoutExpired:
-        return f"⚠️ {error_label}: timeout"
-    except FileNotFoundError:
-        return f"⚠️ {error_label}: {command[0]} CLI not found"
-
-
-def research_with_kimi(content: str, focus_areas: list | None = None) -> str:
-    """Perform deep research using Ollama Kimi."""
+def research_with_ds4(content: str, focus_areas: list | None = None) -> str:
+    """Perform deep research using the local DS4-high route (primary)."""
     prompt = build_research_prompt(content, focus_areas)
-    return run_prompt_command(
-        ["ollama", "run", get_ollama_kimi_model()],
+    api_key = (os.getenv("FINANCE_NEWS_DS4_API_KEY") or "").strip() or None
+    return call_openai_chat(
         prompt,
-        120,
-        "Kimi research error",
+        base_url=get_ds4_base_url(),
+        model=get_ds4_model(),
+        api_key=api_key,
+        max_tokens=RESEARCH_MAX_TOKENS,
+        timeout=RESEARCH_TIMEOUT,
+        error_label="DS4 research error",
     )
 
 
-def research_with_gemini(content: str, focus_areas: list | None = None) -> str:
-    """Perform deep research using Agy CLI fallback."""
+def research_with_qwen(content: str, focus_areas: list | None = None) -> str:
+    """Perform deep research using the local Qwen route (fallback)."""
     prompt = build_research_prompt(content, focus_areas)
-    return run_prompt_command(
-        ["agy", "-p"],
+    api_key = (os.getenv("KALLIOPE_SERVING_API_KEY") or "").strip()
+    if not api_key:
+        return "⚠️ Qwen research error: KALLIOPE_SERVING_API_KEY not set"
+    return call_openai_chat(
         prompt,
-        120,
-        "Agy research error",
-        {"AI_MODEL": get_agy_model()},
+        base_url=get_qwen_base_url(),
+        model=get_qwen_model(),
+        api_key=api_key,
+        max_tokens=RESEARCH_MAX_TOKENS,
+        timeout=RESEARCH_TIMEOUT,
+        error_label="Qwen research error",
     )
 
 
@@ -220,20 +204,20 @@ def generate_research_content(market_data: dict, portfolio_data: dict, focus_are
             'report': '',
             'source': 'none'
         }
-    if kimi_available():
-        report = research_with_kimi(raw_report, focus_areas)
-        if not report.startswith("⚠️"):
-            return {
-                'report': report,
-                'source': 'kimi'
-            }
-    if agy_available():
-        report = research_with_gemini(raw_report, focus_areas)
-        if not report.startswith("⚠️"):
-            return {
-                'report': report,
-                'source': 'gemini'
-            }
+    report = research_with_ds4(raw_report, focus_areas)
+    if not report.startswith("⚠️"):
+        return {
+            'report': report,
+            'source': 'ds4'
+        }
+    print(f"  ↳ {report}; falling back to Qwen route", file=sys.stderr)
+    report = research_with_qwen(raw_report, focus_areas)
+    if not report.startswith("⚠️"):
+        return {
+            'report': report,
+            'source': 'qwen'
+        }
+    print(f"  ↳ {report}; using raw data report", file=sys.stderr)
     return {
         'report': raw_report,
         'source': 'raw'
@@ -282,10 +266,10 @@ def generate_research_report(args):
         print("⚠️ No data available for research", file=sys.stderr)
         return
 
-    if source == 'kimi':
-        print("🔬 Running deep research with Ollama Kimi...", file=sys.stderr)
-    elif source == 'gemini':
-        print("🔬 Running deep research with Agy CLI...", file=sys.stderr)
+    if source == 'ds4':
+        print("🔬 Running deep research with DS4-high route...", file=sys.stderr)
+    elif source == 'qwen':
+        print("🔬 Running deep research with Qwen route...", file=sys.stderr)
     else:
         print("🧾 LLM research unavailable; using raw data report", file=sys.stderr)
     

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """
 News Summarizer - Generate market briefings in configurable language.
-Uses local Ollama Kimi for briefing generation with Agy CLI fallback.
+Uses the local kalliope Qwen route for briefing generation with a local
+gx10 DeepSeek-V4-Flash (DS4) route as fallback.
 """
 
 import argparse
 import json
 import os
 import re
-import subprocess
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -19,7 +19,7 @@ from pathlib import Path
 import urllib.error
 import urllib.parse
 import urllib.request
-from utils import clamp_timeout, compute_deadline, ensure_venv, time_left
+from utils import call_openai_chat, compute_deadline, ensure_venv, time_left
 
 ensure_venv()
 
@@ -41,11 +41,14 @@ PORTFOLIO_MOVER_MAX = 8
 PORTFOLIO_MOVER_MIN_ABS_CHANGE = 1.0
 MAX_HEADLINES_IN_PROMPT = 10
 TOP_HEADLINES_COUNT = 5
-DEFAULT_LLM_FALLBACK = ["kimi", "gemini"]
-DEFAULT_OLLAMA_KIMI_MODEL = "kimi-k2.6:cloud"
-DEFAULT_AGY_MODEL = "gemini-3.5-flash-medium"
-DEFAULT_KIMI_API_BASE_URL = "https://api.kimi.com/coding/"
-DEFAULT_KIMI_API_MODEL = "k2p5"
+DEFAULT_LLM_FALLBACK = ["qwen", "ds4"]
+# Local tailnet routes for all LLM writing/selection/translation.
+# Qwen (kalliope) is the deterministic default writer/selector/translator;
+# DS4 (gx10 DeepSeek-V4-Flash) is the local fallback writer.
+DEFAULT_QWEN_BASE_URL = "http://100.124.155.99:4000/v1"
+DEFAULT_QWEN_MODEL = "qwen3.6:35b-a3b"
+DEFAULT_DS4_BASE_URL = "http://gx10r-head:8888/v1"
+DEFAULT_DS4_MODEL = "deepseek-v4-flash-dspark"
 HEADLINE_SHORTLIST_SIZE = 20
 HEADLINE_MERGE_THRESHOLD = 0.82
 HEADLINE_MAX_AGE_HOURS = 72
@@ -61,7 +64,7 @@ INTL_TICKER_NAME_OVERRIDES = {
     "8411.T": "Mizuho Financial",
 }
 
-SUPPORTED_MODELS = {"kimi", "gemini"}
+SUPPORTED_MODELS = {"qwen", "ds4"}
 
 # Portfolio prioritization weights
 PORTFOLIO_PRIORITY_WEIGHTS = {
@@ -149,27 +152,27 @@ def parse_model_list(raw: str | None, default: list[str]) -> list[str]:
     return result or default
 
 
-def get_ollama_kimi_model() -> str:
+def get_qwen_base_url() -> str:
+    return (os.getenv("FINANCE_NEWS_QWEN_BASE_URL") or DEFAULT_QWEN_BASE_URL).strip()
+
+
+def get_qwen_model() -> str:
     return (
-        os.getenv("FINANCE_NEWS_OLLAMA_KIMI_MODEL")
-        or os.getenv("OLLAMA_KIMI_MODEL")
-        or DEFAULT_OLLAMA_KIMI_MODEL
+        os.getenv("FINANCE_NEWS_QWEN_MODEL")
+        or os.getenv("QWEN_MODEL")
+        or DEFAULT_QWEN_MODEL
     ).strip()
 
 
-def get_kimi_api_model() -> str:
-    return (
-        os.getenv("FINANCE_NEWS_KIMI_MODEL")
-        or os.getenv("KIMI_MODEL")
-        or DEFAULT_KIMI_API_MODEL
-    ).strip()
+def get_ds4_base_url() -> str:
+    return (os.getenv("FINANCE_NEWS_DS4_BASE_URL") or DEFAULT_DS4_BASE_URL).strip()
 
 
-def get_agy_model(default: str = DEFAULT_AGY_MODEL) -> str:
+def get_ds4_model() -> str:
     return (
-        os.getenv("FINANCE_NEWS_AGY_MODEL")
-        or os.getenv("AGY_MODEL")
-        or default
+        os.getenv("FINANCE_NEWS_DS4_MODEL")
+        or os.getenv("DS4_MODEL")
+        or DEFAULT_DS4_MODEL
     ).strip()
 
 
@@ -517,98 +520,39 @@ def extract_agent_reply(raw: str) -> str:
     return raw.strip()
 
 
-def _run_prompt_command(
-    command: list[str],
-    prompt: str,
-    deadline: float | None,
-    timeout: int,
-    error_label: str,
-    env: dict[str, str] | None = None,
-) -> str:
-    try:
-        proc_timeout = clamp_timeout(timeout, deadline)
-        result = subprocess.run(
-            [*command, prompt],
-            capture_output=True,
-            text=True,
-            timeout=proc_timeout,
-            env={**os.environ, **env} if env else None,
-        )
-    except subprocess.TimeoutExpired:
-        return f"⚠️ {error_label}: timeout"
-    except TimeoutError:
-        return f"⚠️ {error_label}: deadline exceeded"
-    except FileNotFoundError:
-        return f"⚠️ {error_label}: {command[0]} CLI not found"
-    except OSError as exc:
-        return f"⚠️ {error_label}: {exc}"
-
-    if result.returncode == 0:
-        return result.stdout.strip()
-
-    stderr = result.stderr.strip() or "unknown error"
-    return f"⚠️ {error_label}: {stderr}"
+def _briefing_max_tokens() -> int:
+    return int(os.getenv("FINANCE_NEWS_BRIEFING_MAX_TOKENS", "1200"))
 
 
-def _kimi_messages_endpoint() -> str:
-    base_url = (os.getenv("KIMI_API_BASE_URL") or DEFAULT_KIMI_API_BASE_URL).strip()
-    return base_url.rstrip("/") + "/v1/messages"
-
-
-def _run_kimi_api_prompt(prompt: str, deadline: float | None, timeout: int) -> str:
-    api_key = (os.getenv("KIMI_API_KEY") or os.getenv("KIMI_API_KEY_WORK") or "").strip()
+def run_qwen_prompt(prompt: str, deadline: float | None = None, timeout: int = 60) -> str:
+    """Call the local kalliope Qwen route (OpenAI-compatible)."""
+    api_key = (os.getenv("KALLIOPE_SERVING_API_KEY") or "").strip()
     if not api_key:
-        return "⚠️ Kimi briefing error: KIMI_API_KEY or KIMI_API_KEY_WORK not set"
-
-    payload = {
-        "model": get_kimi_api_model(),
-        "max_tokens": int(os.getenv("FINANCE_NEWS_KIMI_MAX_TOKENS", "1200")),
-        "messages": [{"role": "user", "content": prompt}],
-    }
-    body = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(
-        _kimi_messages_endpoint(),
-        data=body,
-        headers={
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-        },
-        method="POST",
+        return "⚠️ Qwen briefing error: KALLIOPE_SERVING_API_KEY not set"
+    return call_openai_chat(
+        prompt,
+        base_url=get_qwen_base_url(),
+        model=get_qwen_model(),
+        api_key=api_key,
+        max_tokens=_briefing_max_tokens(),
+        timeout=timeout,
+        deadline=deadline,
+        error_label="Qwen briefing error",
     )
 
-    try:
-        request_timeout = clamp_timeout(timeout, deadline)
-        with urllib.request.urlopen(req, timeout=request_timeout) as response:
-            response_body = json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as exc:
-        error_body = exc.read().decode("utf-8", errors="replace").strip()
-        detail = error_body[:300] if error_body else exc.reason
-        return f"⚠️ Kimi briefing error: HTTP {exc.code}: {detail}"
-    except TimeoutError:
-        return "⚠️ Kimi briefing error: deadline exceeded"
-    except (urllib.error.URLError, OSError) as exc:
-        return f"⚠️ Kimi briefing error: {exc}"
-    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-        return f"⚠️ Kimi briefing error: invalid JSON response: {exc}"
 
-    reply_text = _extract_anthropic_text(response_body)
-    if not reply_text:
-        return "⚠️ Kimi briefing error: empty API response"
-    return reply_text
-
-
-def run_ollama_kimi_prompt(prompt: str, deadline: float | None = None, timeout: int = 60) -> str:
-    return _run_kimi_api_prompt(prompt, deadline, timeout)
-
-
-def run_agy_prompt(prompt: str, deadline: float | None = None, timeout: int = 60) -> str:
-    return _run_prompt_command(
-        ["agy", "-p"],
+def run_ds4_prompt(prompt: str, deadline: float | None = None, timeout: int = 60) -> str:
+    """Call the local gx10 DeepSeek-V4-Flash (DS4) route (OpenAI-compatible)."""
+    api_key = (os.getenv("FINANCE_NEWS_DS4_API_KEY") or "").strip() or None
+    return call_openai_chat(
         prompt,
-        deadline,
-        timeout,
-        "Agy briefing error",
-        env={"AI_MODEL": get_agy_model()},
+        base_url=get_ds4_base_url(),
+        model=get_ds4_model(),
+        api_key=api_key,
+        max_tokens=_briefing_max_tokens(),
+        timeout=timeout,
+        deadline=deadline,
+        error_label="DS4 briefing error",
     )
 
 
@@ -618,14 +562,14 @@ def run_agent_prompt(
     session_id: str = "finance-news-headlines",
     timeout: int = 45,
 ) -> str:
-    """Run a prompt through Ollama Kimi, then Agy CLI if Kimi fails."""
+    """Run a prompt through the local Qwen route, then the local DS4 route on failure."""
     del session_id
-    reply = run_ollama_kimi_prompt(prompt, deadline=deadline, timeout=timeout)
+    reply = run_qwen_prompt(prompt, deadline=deadline, timeout=timeout)
     if not reply.startswith("⚠️"):
         return reply
 
-    print(f"  ↳ {reply}; falling back to agy -p", file=sys.stderr)
-    return run_agy_prompt(prompt, deadline=deadline, timeout=timeout)
+    print(f"  ↳ {reply}; falling back to DS4 route", file=sys.stderr)
+    return run_ds4_prompt(prompt, deadline=deadline, timeout=timeout)
 
 
 def normalize_title(title: str) -> str:
@@ -1144,22 +1088,22 @@ def translate_headlines(
 ) -> tuple[list[str], bool]:
     """Translate headlines to German using LLM.
 
-    Uses local Ollama Kimi first, then Agy CLI.
+    Uses the local Qwen route first, then the local DS4 route.
     Returns (translated_titles, success) or (original_titles, False) on failure.
     """
     if not titles:
         return [], True
 
     print(f"🔤 Translating {len(titles)} headlines...", file=sys.stderr)
-    translated, success = translate_via_ollama_kimi(titles, deadline=deadline)
+    translated, success = translate_via_qwen(titles, deadline=deadline)
     if success:
-        print("  ↳ ✅ Translation successful via Ollama Kimi", file=sys.stderr)
+        print("  ↳ ✅ Translation successful via Qwen", file=sys.stderr)
         return translated, True
 
-    print("  ↳ Ollama Kimi failed, falling back to agy -p", file=sys.stderr)
-    translated, success = translate_via_agy_cli(titles, deadline=deadline)
+    print("  ↳ Qwen failed, falling back to DS4 route", file=sys.stderr)
+    translated, success = translate_via_ds4(titles, deadline=deadline)
     if success:
-        print("  ↳ ✅ Translation successful via Agy CLI", file=sys.stderr)
+        print("  ↳ ✅ Translation successful via DS4", file=sys.stderr)
         return translated, True
 
     return titles, False
@@ -1181,20 +1125,6 @@ def parse_translation_array(raw_text: str) -> list[str] | None:
     if isinstance(data, list) and all(isinstance(item, str) for item in data):
         return data
     return None
-
-
-def _extract_anthropic_text(body: dict) -> str | None:
-    """Extract text content from an Anthropic-compatible API response body."""
-    content = body.get("content", [])
-    if not isinstance(content, list):
-        return None
-    text_parts = [
-        block.get("text", "")
-        for block in content
-        if isinstance(block, dict) and block.get("type") == "text"
-    ]
-    reply_text = "\n".join([p for p in text_parts if isinstance(p, str)]).strip()
-    return reply_text or None
 
 
 def _translate_via_prompt_runner(
@@ -1222,18 +1152,18 @@ def _translate_via_prompt_runner(
     return translated, True
 
 
-def translate_via_ollama_kimi(
+def translate_via_qwen(
     titles: list[str],
     deadline: float | None,
 ) -> tuple[list[str], bool]:
-    return _translate_via_prompt_runner(titles, deadline, run_ollama_kimi_prompt, "Ollama Kimi")
+    return _translate_via_prompt_runner(titles, deadline, run_qwen_prompt, "Qwen")
 
 
-def translate_via_agy_cli(
+def translate_via_ds4(
     titles: list[str],
     deadline: float | None,
 ) -> tuple[list[str], bool]:
-    return _translate_via_prompt_runner(titles, deadline, run_agy_prompt, "Agy CLI")
+    return _translate_via_prompt_runner(titles, deadline, run_ds4_prompt, "DS4")
 
 
 def translate_headline_items(headlines: list[dict], deadline: float | None) -> bool:
@@ -1328,29 +1258,29 @@ Here are the current market items:
 """
 
 
-def summarize_with_kimi(
+def summarize_with_qwen(
     content: str,
     language: str = "de",
     style: str = "briefing",
     deadline: float | None = None,
 ) -> str:
-    """Generate AI summary using Ollama Kimi."""
+    """Generate AI summary using the local Qwen route."""
     prompt = _build_summary_prompt(content, language, style)
-    reply_text = run_ollama_kimi_prompt(prompt, deadline=deadline, timeout=60)
+    reply_text = run_qwen_prompt(prompt, deadline=deadline, timeout=60)
     if reply_text.startswith("⚠️"):
         return reply_text
     return reply_text + format_disclaimer(language)
 
 
-def summarize_with_gemini(
+def summarize_with_ds4(
     content: str,
     language: str = "de",
     style: str = "briefing",
     deadline: float | None = None,
 ) -> str:
-    """Generate AI summary using Agy CLI fallback."""
+    """Generate AI summary using the local DS4 route (fallback writer)."""
     prompt = _build_summary_prompt(content, language, style)
-    reply_text = run_agy_prompt(prompt, deadline=deadline, timeout=60)
+    reply_text = run_ds4_prompt(prompt, deadline=deadline, timeout=60)
     if reply_text.startswith("⚠️"):
         return reply_text
     return reply_text + format_disclaimer(language)
@@ -1900,7 +1830,7 @@ def generate_briefing(args):
     )
 
     # Headline selection uses deterministic ranking first; the LLM path uses
-    # local Ollama Kimi with Agy CLI fallback.
+    # the local Qwen route with a local DS4 route fallback.
 
     shortlist_by_lang = config.get("headline_shortlist_size_by_lang", {})
     shortlist_size = HEADLINE_SHORTLIST_SIZE
@@ -2020,8 +1950,8 @@ def generate_briefing(args):
     else:
         content = raw_content
 
-    model = getattr(args, 'model', "kimi")
-    # Kimi is the active writer for the supported summary styles. The outer
+    model = getattr(args, 'model', "qwen")
+    # Qwen is the active writer for the supported summary styles. The outer
     # caller may still pass --llm, but briefing no longer relies on that flag
     # to enter the AI path.
     use_llm = True
@@ -2067,10 +1997,10 @@ def generate_briefing(args):
         summary_mode = "llm"
         summary_model_used = "llm_failed"
         for candidate in summary_list:
-            if candidate == "kimi":
-                summary = summarize_with_kimi(content, language, args.style, deadline=deadline)
-            elif candidate == "gemini":
-                summary = summarize_with_gemini(content, language, args.style, deadline=deadline)
+            if candidate == "qwen":
+                summary = summarize_with_qwen(content, language, args.style, deadline=deadline)
+            elif candidate == "ds4":
+                summary = summarize_with_ds4(content, language, args.style, deadline=deadline)
             else:
                 summary = f"⚠️ Unsupported summary model: {candidate}"
 
@@ -2091,7 +2021,7 @@ def generate_briefing(args):
             raise RuntimeError(f"Briefing requires LLM writer, got {summary_model_used}")
         summary_structure_ok, summary_missing_sections = validate_briefing_structure(summary, labels)
         if not summary_structure_ok:
-            raise RuntimeError("Kimi briefing missing required sections: " + ", ".join(summary_missing_sections))
+            raise RuntimeError("Briefing missing required sections: " + ", ".join(summary_missing_sections))
 
     if args.debug:
         debug_payload.update({
@@ -2227,9 +2157,9 @@ def main():
                         default=None, help='Briefing type (default: auto)')
     parser.add_argument('--json', action='store_true', help='Output as JSON')
     parser.add_argument('--research', action='store_true', help='Include deep research section (slower)')
-    parser.add_argument('--llm', action='store_true', help='Force LLM summary for non-briefing styles (briefing uses Kimi by default)')
-    parser.add_argument('--model', choices=sorted(SUPPORTED_MODELS), default='kimi',
-                        help='Kimi provider override')
+    parser.add_argument('--llm', action='store_true', help='Force LLM summary for non-briefing styles (briefing uses Qwen by default)')
+    parser.add_argument('--model', choices=sorted(SUPPORTED_MODELS), default='qwen',
+                        help='Local writer route override (qwen or ds4)')
     parser.add_argument('--deadline', type=int, default=None, help='Overall deadline in seconds')
     parser.add_argument('--fast', action='store_true', help='Use fast mode (shorter timeouts, fewer items)')
     parser.add_argument('--debug', action='store_true', help='Write debug log with sources')

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,8 +1,11 @@
 """Shared helpers."""
 
+import json
 import os
 import sys
 import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 
@@ -45,3 +48,83 @@ def clamp_timeout(default_timeout: int, deadline: float | None, minimum: int = 1
     if remaining <= 0:
         raise TimeoutError("Deadline exceeded")
     return max(min(default_timeout, remaining), minimum)
+
+
+def _extract_openai_text(body: dict) -> str | None:
+    """Extract assistant text from an OpenAI-compatible chat-completions response."""
+    choices = body.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return None
+    first = choices[0]
+    if not isinstance(first, dict):
+        return None
+    message = first.get("message")
+    if not isinstance(message, dict):
+        return None
+    content = message.get("content")
+    if isinstance(content, str):
+        return content.strip() or None
+    # Some servers stream content back as a list of typed parts.
+    if isinstance(content, list):
+        parts = [
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and isinstance(part.get("text"), str)
+        ]
+        joined = "".join(parts).strip()
+        return joined or None
+    return None
+
+
+def call_openai_chat(
+    prompt: str,
+    *,
+    base_url: str,
+    model: str,
+    api_key: str | None = None,
+    max_tokens: int = 1200,
+    timeout: int = 60,
+    deadline: float | None = None,
+    error_label: str = "LLM error",
+    temperature: float = 0.0,
+) -> str:
+    """Call an OpenAI-compatible ``/chat/completions`` endpoint with a single user
+    message and return the assistant text.
+
+    Used to reach the local tailnet routes (kalliope Qwen, gx10 DeepSeek-V4-Flash).
+    On any transport, HTTP, or decoding failure it returns a
+    ``"⚠️ {error_label}: ..."`` sentinel so callers can fall back or degrade
+    gracefully, matching the existing prompt-runner contract.
+    """
+    endpoint = base_url.rstrip("/") + "/chat/completions"
+    payload = {
+        "model": model,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(endpoint, data=body, headers=headers, method="POST")
+
+    try:
+        request_timeout = clamp_timeout(timeout, deadline)
+        with urllib.request.urlopen(req, timeout=request_timeout) as response:
+            response_body = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        error_body = exc.read().decode("utf-8", errors="replace").strip()
+        detail = error_body[:300] if error_body else exc.reason
+        return f"⚠️ {error_label}: HTTP {exc.code}: {detail}"
+    except TimeoutError:
+        return f"⚠️ {error_label}: deadline exceeded"
+    except (urllib.error.URLError, OSError) as exc:
+        return f"⚠️ {error_label}: {exc}"
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return f"⚠️ {error_label}: invalid JSON response: {exc}"
+
+    reply_text = _extract_openai_text(response_body)
+    if not reply_text:
+        return f"⚠️ {error_label}: empty API response"
+    return reply_text

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -1,26 +1,23 @@
 """Tests for research.py - deep research module."""
 
-import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
 # Add scripts to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
+import research
 from research import (
     format_headlines,
     format_market_data,
     format_portfolio_news,
     format_raw_data_report,
-    agy_available,
     generate_research_content,
-    kimi_available,
-    ollama_available,
-    research_with_gemini,
-    research_with_kimi,
+    research_with_ds4,
+    research_with_qwen,
 )
 
 
@@ -212,102 +209,83 @@ class TestFormatPortfolioNews:
         assert "## Portfolio Analysis" in result
 
 
-class TestProviderAvailability:
-    """Tests for local LLM provider availability."""
+class TestResearchWithDS4:
+    """Tests for research_with_ds4() - the DS4-high primary route."""
 
-    def test_returns_true_when_ollama_found(self):
-        """Return True when ollama CLI is found."""
-        with patch("shutil.which", return_value="/usr/local/bin/ollama"):
-            assert ollama_available() is True
+    def test_successful_research(self, monkeypatch):
+        """Execute DS4 research successfully against the local route."""
+        captured = {}
 
-    def test_returns_false_when_ollama_not_found(self):
-        """Return False when ollama CLI is not found."""
-        with patch("shutil.which", return_value=None):
-            assert ollama_available() is False
+        def fake_call(prompt, **kwargs):
+            captured["prompt"] = prompt
+            captured["kwargs"] = kwargs
+            return "# Research Report\n\nMarket analysis..."
 
-    def test_kimi_available_aliases_ollama(self):
-        """Kimi availability is backed by Ollama."""
-        with patch("shutil.which", return_value="/usr/local/bin/ollama"):
-            assert kimi_available() is True
+        monkeypatch.setenv("FINANCE_NEWS_DS4_BASE_URL", "http://ds4.test/v1")
+        monkeypatch.setenv("FINANCE_NEWS_DS4_MODEL", "ds4-test")
+        monkeypatch.setattr(research, "call_openai_chat", fake_call)
 
-    def test_agy_available_checks_agy(self):
-        """Agy fallback availability checks agy CLI."""
-        with patch("shutil.which", return_value="/usr/local/bin/agy"):
-            assert agy_available() is True
+        result = research_with_ds4("Market data content")
 
+        assert result == "# Research Report\n\nMarket analysis..."
+        assert captured["kwargs"]["base_url"] == "http://ds4.test/v1"
+        assert captured["kwargs"]["model"] == "ds4-test"
 
-class TestResearchWithKimi:
-    """Tests for research_with_kimi()."""
-
-    def test_successful_research(self):
-        """Execute Ollama Kimi research successfully."""
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stdout = "# Research Report\n\nMarket analysis..."
-
-        with patch("subprocess.run", return_value=mock_result) as mock_run:
-            result = research_with_kimi("Market data content")
-
-            assert result == "# Research Report\n\nMarket analysis..."
-            mock_run.assert_called_once()
-            assert mock_run.call_args[0][0][:3] == ["ollama", "run", "kimi-k2.6:cloud"]
-
-    def test_research_with_focus_areas(self):
+    def test_research_with_focus_areas(self, monkeypatch):
         """Include focus areas in prompt."""
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stdout = "Focused analysis"
+        captured = {}
 
-        with patch("subprocess.run", return_value=mock_result) as mock_run:
-            result = research_with_kimi("content", focus_areas=["earnings", "macro"])
+        def fake_call(prompt, **kwargs):
+            captured["prompt"] = prompt
+            return "Focused analysis"
 
-            assert result == "Focused analysis"
-            # Verify focus areas were in the prompt
-            call_args = mock_run.call_args[0][0]
-            prompt = call_args[-1]
-            assert "earnings" in prompt
-            assert "macro" in prompt
+        monkeypatch.setattr(research, "call_openai_chat", fake_call)
 
-    def test_handles_kimi_error(self):
-        """Handle Kimi error gracefully."""
-        mock_result = Mock()
-        mock_result.returncode = 1
-        mock_result.stderr = "API error"
+        result = research_with_ds4("content", focus_areas=["earnings", "macro"])
 
-        with patch("subprocess.run", return_value=mock_result):
-            result = research_with_kimi("content")
+        assert result == "Focused analysis"
+        assert "earnings" in captured["prompt"]
+        assert "macro" in captured["prompt"]
 
-            assert "⚠️ Kimi research error" in result
-            assert "API error" in result
+    def test_handles_route_error(self, monkeypatch):
+        """Handle DS4 route error gracefully (sentinel passthrough)."""
+        monkeypatch.setattr(
+            research,
+            "call_openai_chat",
+            lambda *_a, **_k: "⚠️ DS4 research error: HTTP 503: unavailable",
+        )
+        result = research_with_ds4("content")
 
-    def test_handles_timeout(self):
-        """Handle subprocess timeout."""
-        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="ollama", timeout=120)):
-            result = research_with_kimi("content")
-
-            assert "⚠️ Kimi research error: timeout" in result
-
-    def test_handles_missing_ollama(self):
-        """Handle missing ollama CLI."""
-        with patch("subprocess.run", side_effect=FileNotFoundError()):
-            result = research_with_kimi("content")
-
-            assert "⚠️ Kimi research error: ollama CLI not found" in result
+        assert "⚠️ DS4 research error" in result
 
 
-class TestResearchWithGemini:
-    """Tests for research_with_gemini()."""
+class TestResearchWithQwen:
+    """Tests for research_with_qwen() - the Qwen fallback route."""
 
-    def test_research_with_gemini_uses_agy_cli(self):
-        """Fallback uses agy -p with high-thinking model by default."""
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stdout = "Agy report"
+    def test_uses_qwen_route(self, monkeypatch):
+        """Fallback calls the local Qwen route with the serving key."""
+        captured = {}
 
-        with patch("subprocess.run", return_value=mock_result) as mock_run:
-            assert research_with_gemini("content") == "Agy report"
-            assert mock_run.call_args[0][0][:2] == ["agy", "-p"]
-            assert mock_run.call_args.kwargs["env"]["AI_MODEL"] == "gemini-3.5-flash-high"
+        def fake_call(prompt, **kwargs):
+            captured["kwargs"] = kwargs
+            return "Qwen report"
+
+        monkeypatch.setenv("KALLIOPE_SERVING_API_KEY", "serving-key")
+        monkeypatch.setenv("FINANCE_NEWS_QWEN_BASE_URL", "http://qwen.test/v1")
+        monkeypatch.setenv("FINANCE_NEWS_QWEN_MODEL", "qwen-test")
+        monkeypatch.setattr(research, "call_openai_chat", fake_call)
+
+        assert research_with_qwen("content") == "Qwen report"
+        assert captured["kwargs"]["base_url"] == "http://qwen.test/v1"
+        assert captured["kwargs"]["model"] == "qwen-test"
+        assert captured["kwargs"]["api_key"] == "serving-key"
+
+    def test_requires_serving_key(self, monkeypatch):
+        """Fail closed when the serving key is missing."""
+        monkeypatch.delenv("KALLIOPE_SERVING_API_KEY", raising=False)
+        result = research_with_qwen("content")
+
+        assert result == "⚠️ Qwen research error: KALLIOPE_SERVING_API_KEY not set"
 
 
 class TestFormatRawDataReport:
@@ -345,32 +323,29 @@ class TestFormatRawDataReport:
 class TestGenerateResearchContent:
     """Tests for generate_research_content()."""
 
-    def test_uses_kimi_when_available(self, sample_market_data, sample_portfolio_data):
-        """Use Kimi research when available."""
-        with patch("research.kimi_available", return_value=True):
-            with patch("research.research_with_kimi", return_value="Kimi report") as mock_kimi:
+    def test_uses_ds4_primary(self, sample_market_data, sample_portfolio_data):
+        """Use the DS4-high route as the deep-research primary."""
+        with patch("research.research_with_ds4", return_value="DS4 report") as mock_ds4:
+            result = generate_research_content(sample_market_data, sample_portfolio_data)
+
+            assert result["report"] == "DS4 report"
+            assert result["source"] == "ds4"
+            mock_ds4.assert_called_once()
+
+    def test_falls_back_to_qwen_when_ds4_fails(self, sample_market_data, sample_portfolio_data):
+        """Use the Qwen route when the DS4 route fails."""
+        with patch("research.research_with_ds4", return_value="⚠️ DS4 research error: timeout"):
+            with patch("research.research_with_qwen", return_value="Qwen report") as mock_qwen:
                 result = generate_research_content(sample_market_data, sample_portfolio_data)
 
-                assert result["report"] == "Kimi report"
-                assert result["source"] == "kimi"
-                mock_kimi.assert_called_once()
-
-    def test_falls_back_to_gemini_when_kimi_fails(self, sample_market_data, sample_portfolio_data):
-        """Use Gemini when Kimi is unavailable or fails."""
-        with patch("research.kimi_available", return_value=True):
-            with patch("research.research_with_kimi", return_value="⚠️ Kimi research error: timeout"):
-                with patch("research.agy_available", return_value=True):
-                    with patch("research.research_with_gemini", return_value="Gemini report") as mock_gemini:
-                        result = generate_research_content(sample_market_data, sample_portfolio_data)
-
-                        assert result["report"] == "Gemini report"
-                        assert result["source"] == "gemini"
-                        mock_gemini.assert_called_once()
+                assert result["report"] == "Qwen report"
+                assert result["source"] == "qwen"
+                mock_qwen.assert_called_once()
 
     def test_falls_back_to_raw_report(self, sample_market_data, sample_portfolio_data):
-        """Fall back to raw report when LLM providers are unavailable."""
-        with patch("research.kimi_available", return_value=False):
-            with patch("research.agy_available", return_value=False):
+        """Fall back to raw report when both local routes fail."""
+        with patch("research.research_with_ds4", return_value="⚠️ DS4 research error: timeout"):
+            with patch("research.research_with_qwen", return_value="⚠️ Qwen research error: timeout"):
                 result = generate_research_content(sample_market_data, sample_portfolio_data)
 
             assert "## Market Data" in result["report"]
@@ -383,15 +358,13 @@ class TestGenerateResearchContent:
         assert result["report"] == ""
         assert result["source"] == "none"
 
-    def test_passes_focus_areas_to_kimi(self, sample_market_data, sample_portfolio_data):
-        """Pass focus areas to Kimi research."""
+    def test_passes_focus_areas_to_ds4(self, sample_market_data, sample_portfolio_data):
+        """Pass focus areas to DS4 research."""
         focus = ["earnings", "tech"]
-        with patch("research.kimi_available", return_value=True):
-            with patch("research.research_with_kimi", return_value="Report") as mock_kimi:
-                generate_research_content(sample_market_data, sample_portfolio_data, focus_areas=focus)
+        with patch("research.research_with_ds4", return_value="Report") as mock_ds4:
+            generate_research_content(sample_market_data, sample_portfolio_data, focus_areas=focus)
 
-                mock_kimi.assert_called_once()
-                # Check that focus_areas was passed (positional or keyword)
-                call_args = mock_kimi.call_args
-                # Focus areas passed as second positional arg
-                assert call_args[0][1] == focus or call_args.kwargs.get("focus_areas") == focus
+            mock_ds4.assert_called_once()
+            # Focus areas passed as second positional arg
+            call_args = mock_ds4.call_args
+            assert call_args[0][1] == focus or call_args.kwargs.get("focus_areas") == focus

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from datetime import datetime
-from unittest.mock import Mock
 
 import summarize
 from summarize import (
@@ -74,7 +73,9 @@ def test_format_market_data_handles_non_numeric_change_percent():
     assert "- Nasdaq: 22450 (N/A)" in result
 
 
-def test_run_ollama_kimi_prompt_calls_kimi_api(monkeypatch):
+def test_run_qwen_prompt_calls_qwen_api(monkeypatch):
+    import utils
+
     captured = {}
 
     def fake_urlopen(req, timeout):
@@ -82,30 +83,53 @@ def test_run_ollama_kimi_prompt_calls_kimi_api(monkeypatch):
         captured["timeout"] = timeout
         captured["headers"] = dict(req.header_items())
         captured["payload"] = json.loads(req.data.decode("utf-8"))
-        return _FakeUrlopenResponse({"content": [{"type": "text", "text": "Kimi response"}]})
+        return _FakeUrlopenResponse({"choices": [{"message": {"content": "Qwen response"}}]})
 
-    monkeypatch.setenv("KIMI_API_KEY", "test-key")
-    monkeypatch.setenv("KIMI_API_BASE_URL", "https://api.kimi.test/coding/")
-    monkeypatch.setenv("FINANCE_NEWS_KIMI_MODEL", "k2p5-test")
-    monkeypatch.setattr(summarize.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setenv("KALLIOPE_SERVING_API_KEY", "test-key")
+    monkeypatch.setenv("FINANCE_NEWS_QWEN_BASE_URL", "http://qwen.test/v1")
+    monkeypatch.setenv("FINANCE_NEWS_QWEN_MODEL", "qwen-test")
+    monkeypatch.setattr(utils.urllib.request, "urlopen", fake_urlopen)
 
-    result = summarize.run_ollama_kimi_prompt("Write a briefing", deadline=None, timeout=45)
+    result = summarize.run_qwen_prompt("Write a briefing", deadline=None, timeout=45)
 
-    assert result == "Kimi response"
-    assert captured["url"] == "https://api.kimi.test/coding/v1/messages"
+    assert result == "Qwen response"
+    assert captured["url"] == "http://qwen.test/v1/chat/completions"
     assert captured["timeout"] == 45
     assert captured["headers"]["Authorization"] == "Bearer test-key"
-    assert captured["payload"]["model"] == "k2p5-test"
+    assert captured["payload"]["model"] == "qwen-test"
     assert captured["payload"]["messages"] == [{"role": "user", "content": "Write a briefing"}]
 
 
-def test_run_ollama_kimi_prompt_requires_kimi_key(monkeypatch):
-    monkeypatch.delenv("KIMI_API_KEY", raising=False)
-    monkeypatch.delenv("KIMI_API_KEY_WORK", raising=False)
+def test_run_qwen_prompt_requires_api_key(monkeypatch):
+    monkeypatch.delenv("KALLIOPE_SERVING_API_KEY", raising=False)
 
-    result = summarize.run_ollama_kimi_prompt("Write a briefing", deadline=None, timeout=45)
+    result = summarize.run_qwen_prompt("Write a briefing", deadline=None, timeout=45)
 
-    assert result == "⚠️ Kimi briefing error: KIMI_API_KEY or KIMI_API_KEY_WORK not set"
+    assert result == "⚠️ Qwen briefing error: KALLIOPE_SERVING_API_KEY not set"
+
+
+def test_run_ds4_prompt_calls_ds4_api_without_key(monkeypatch):
+    import utils
+
+    captured = {}
+
+    def fake_urlopen(req, timeout):
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.header_items())
+        captured["payload"] = json.loads(req.data.decode("utf-8"))
+        return _FakeUrlopenResponse({"choices": [{"message": {"content": "DS4 response"}}]})
+
+    monkeypatch.delenv("FINANCE_NEWS_DS4_API_KEY", raising=False)
+    monkeypatch.setenv("FINANCE_NEWS_DS4_BASE_URL", "http://ds4.test/v1")
+    monkeypatch.setenv("FINANCE_NEWS_DS4_MODEL", "ds4-test")
+    monkeypatch.setattr(utils.urllib.request, "urlopen", fake_urlopen)
+
+    result = summarize.run_ds4_prompt("Write a briefing", deadline=None, timeout=45)
+
+    assert result == "DS4 response"
+    assert captured["url"] == "http://ds4.test/v1/chat/completions"
+    assert "Authorization" not in captured["headers"]
+    assert captured["payload"]["model"] == "ds4-test"
 
 
 def test_extract_portfolio_movers_reuses_existing_quotes():
@@ -147,99 +171,87 @@ def test_format_whatsapp_message_replaces_markdown_headings_and_bold():
     ]
 
 
-def test_translate_via_ollama_kimi_parses_markdown_json(monkeypatch):
+def test_translate_via_qwen_parses_markdown_json(monkeypatch):
     monkeypatch.setattr(
         summarize,
-        "run_ollama_kimi_prompt",
+        "run_qwen_prompt",
         lambda *_a, **_k: "```json\n[\"Titel A\", \"Titel B\"]\n```",
     )
 
-    translated, success = summarize.translate_via_ollama_kimi(["Title A", "Title B"], deadline=None)
+    translated, success = summarize.translate_via_qwen(["Title A", "Title B"], deadline=None)
     assert success is True
     assert translated == ["Titel A", "Titel B"]
 
 
-def test_translate_headlines_uses_ollama_kimi_first(monkeypatch):
+def test_translate_headlines_uses_qwen_first(monkeypatch):
     monkeypatch.setattr(
         summarize,
-        "translate_via_ollama_kimi",
+        "translate_via_qwen",
         lambda titles, deadline: (["Titel"], True),
     )
 
     def fail_if_called(*_args, **_kwargs):
-        raise AssertionError("Agy fallback should not be called when Kimi succeeds")
+        raise AssertionError("DS4 fallback should not be called when Qwen succeeds")
 
-    monkeypatch.setattr(summarize, "translate_via_agy_cli", fail_if_called)
+    monkeypatch.setattr(summarize, "translate_via_ds4", fail_if_called)
 
     translated, success = summarize.translate_headlines(["Title"], deadline=None)
     assert success is True
     assert translated == ["Titel"]
 
 
-def test_translate_headlines_falls_back_to_agy(monkeypatch):
+def test_translate_headlines_falls_back_to_ds4(monkeypatch):
     monkeypatch.setattr(
         summarize,
-        "translate_via_ollama_kimi",
+        "translate_via_qwen",
         lambda titles, deadline: (titles, False),
     )
-    monkeypatch.setattr(summarize, "translate_via_agy_cli", lambda titles, deadline: (["Titel"], True))
+    monkeypatch.setattr(summarize, "translate_via_ds4", lambda titles, deadline: (["Titel"], True))
 
     translated, success = summarize.translate_headlines(["Title"], deadline=None)
     assert success is True
     assert translated == ["Titel"]
 
 
-def test_translate_via_ollama_kimi_timeout(monkeypatch):
+def test_translate_via_qwen_timeout(monkeypatch):
     """Falls back on timeout."""
-    monkeypatch.setattr(summarize, "run_ollama_kimi_prompt", lambda *_a, **_k: "⚠️ Kimi briefing error: timeout")
+    monkeypatch.setattr(summarize, "run_qwen_prompt", lambda *_a, **_k: "⚠️ Qwen briefing error: timeout")
 
-    translated, success = summarize.translate_via_ollama_kimi(["Title"], deadline=None)
+    translated, success = summarize.translate_via_qwen(["Title"], deadline=None)
     assert success is False
     assert translated == ["Title"]
 
 
-def test_translate_via_ollama_kimi_malformed_json(monkeypatch):
+def test_translate_via_qwen_malformed_json(monkeypatch):
     """Falls back when provider returns non-JSON."""
-    monkeypatch.setattr(summarize, "run_ollama_kimi_prompt", lambda *_a, **_k: "not json at all")
+    monkeypatch.setattr(summarize, "run_qwen_prompt", lambda *_a, **_k: "not json at all")
 
-    translated, success = summarize.translate_via_ollama_kimi(["Title"], deadline=None)
+    translated, success = summarize.translate_via_qwen(["Title"], deadline=None)
     assert success is False
     assert translated == ["Title"]
 
 
-def test_translate_via_ollama_kimi_length_mismatch(monkeypatch):
+def test_translate_via_qwen_length_mismatch(monkeypatch):
     """Falls back when API returns wrong number of translations."""
-    monkeypatch.setattr(summarize, "run_ollama_kimi_prompt", lambda *_a, **_k: '["Only One"]')
+    monkeypatch.setattr(summarize, "run_qwen_prompt", lambda *_a, **_k: '["Only One"]')
 
-    translated, success = summarize.translate_via_ollama_kimi(
+    translated, success = summarize.translate_via_qwen(
         ["Title A", "Title B", "Title C"], deadline=None,
     )
     assert success is False
     assert translated == ["Title A", "Title B", "Title C"]
 
 
-def test_translate_via_agy_cli_success(monkeypatch):
-    monkeypatch.setattr(summarize, "run_agy_prompt", lambda *_a, **_k: '["Titel"]')
-    translated, success = summarize.translate_via_agy_cli(["Title"], deadline=None)
+def test_translate_via_ds4_success(monkeypatch):
+    monkeypatch.setattr(summarize, "run_ds4_prompt", lambda *_a, **_k: '["Titel"]')
+    translated, success = summarize.translate_via_ds4(["Title"], deadline=None)
     assert success is True
     assert translated == ["Titel"]
 
 
-def test_run_agy_prompt_sets_medium_model(monkeypatch):
-    result = Mock()
-    result.returncode = 0
-    result.stdout = "OK"
-    monkeypatch.setattr(summarize.subprocess, "run", Mock(return_value=result))
-
-    assert summarize.run_agy_prompt("prompt", deadline=None) == "OK"
-    call = summarize.subprocess.run.call_args
-    assert call[0][0][:2] == ["agy", "-p"]
-    assert call.kwargs["env"]["AI_MODEL"] == "gemini-3.5-flash-medium"
-
-
-def test_translate_via_ollama_kimi_empty_list():
+def test_translate_via_qwen_empty_list():
     """Returns empty list for empty input."""
-    translated, success = summarize.translate_via_ollama_kimi([], deadline=None)
+    translated, success = summarize.translate_via_qwen([], deadline=None)
     assert success is True
     assert translated == []
 
@@ -616,7 +628,7 @@ Beobachten.
     monkeypatch.setattr(summarize, "get_market_news", fake_market_news)
     monkeypatch.setattr(summarize, "get_portfolio_news", lambda *_a, **_k: None)
     monkeypatch.setattr(summarize, "get_portfolio_movers", lambda *_a, **_k: {"movers": []})
-    monkeypatch.setattr(summarize, "summarize_with_kimi", fake_summary)
+    monkeypatch.setattr(summarize, "summarize_with_qwen", fake_summary)
     monkeypatch.setattr(summarize, "validate_briefing_structure", lambda *_a, **_k: (True, []))
     monkeypatch.setattr(summarize, "datetime", FixedDateTime)
 
@@ -627,7 +639,7 @@ Beobachten.
             "lang": "de",
             "style": "briefing",
             "time": None,
-            "model": "kimi",
+            "model": "qwen",
             "json": False,
             "research": False,
             "deadline": None,
@@ -642,7 +654,7 @@ Beobachten.
     assert "Börsen Abend-Briefing" in stdout
 
 
-def test_summarize_with_kimi_uses_localized_briefing_headings(monkeypatch):
+def test_summarize_with_qwen_uses_localized_briefing_headings(monkeypatch):
     captured = {}
 
     def fake_runner(prompt, deadline=None, timeout=60):
@@ -650,46 +662,46 @@ def test_summarize_with_kimi_uses_localized_briefing_headings(monkeypatch):
         captured["timeout"] = timeout
         return "### Märkte\n\nAlles ruhig."
 
-    monkeypatch.setattr(summarize, "run_ollama_kimi_prompt", fake_runner)
+    monkeypatch.setattr(summarize, "run_qwen_prompt", fake_runner)
 
-    summary = summarize.summarize_with_kimi("Raw content", language="de", style="briefing", deadline=None)
+    summary = summarize.summarize_with_qwen("Raw content", language="de", style="briefing", deadline=None)
     prompt = captured["prompt"]
     assert "### Märkte" in prompt
     assert "### Sentiment" not in prompt
     assert summary.startswith("### Märkte")
 
 
-def test_summarize_with_kimi_success(monkeypatch):
+def test_summarize_with_qwen_success(monkeypatch):
     captured = {}
 
     def fake_runner(prompt, deadline=None, timeout=60):
         captured["prompt"] = prompt
         captured["timeout"] = timeout
-        return "## Market Briefing\n\nKimi summary body"
+        return "## Market Briefing\n\nQwen summary body"
 
-    monkeypatch.setattr(summarize, "run_ollama_kimi_prompt", fake_runner)
+    monkeypatch.setattr(summarize, "run_qwen_prompt", fake_runner)
 
-    summary = summarize.summarize_with_kimi("Raw content", language="en", style="briefing", deadline=None)
-    assert "Kimi summary body" in summary
+    summary = summarize.summarize_with_qwen("Raw content", language="en", style="briefing", deadline=None)
+    assert "Qwen summary body" in summary
     assert "informational purposes only" in summary
     assert "Raw content" in captured["prompt"]
     assert captured["timeout"] == 60
 
 
-def test_summarize_with_kimi_missing_ollama(monkeypatch):
+def test_summarize_with_qwen_error_passthrough(monkeypatch):
     monkeypatch.setattr(
         summarize,
-        "run_ollama_kimi_prompt",
-        lambda *_a, **_k: "⚠️ Kimi briefing error: ollama CLI not found",
+        "run_qwen_prompt",
+        lambda *_a, **_k: "⚠️ Qwen briefing error: KALLIOPE_SERVING_API_KEY not set",
     )
-    summary = summarize.summarize_with_kimi("Raw content", language="en", style="briefing", deadline=None)
-    assert summary == "⚠️ Kimi briefing error: ollama CLI not found"
+    summary = summarize.summarize_with_qwen("Raw content", language="en", style="briefing", deadline=None)
+    assert summary == "⚠️ Qwen briefing error: KALLIOPE_SERVING_API_KEY not set"
 
 
-def test_summarize_with_gemini_success(monkeypatch):
-    monkeypatch.setattr(summarize, "run_agy_prompt", lambda *_a, **_k: "## Analysis\n\nAgy body")
-    summary = summarize.summarize_with_gemini("Raw content", language="en", style="analysis", deadline=None)
-    assert "Agy body" in summary
+def test_summarize_with_ds4_success(monkeypatch):
+    monkeypatch.setattr(summarize, "run_ds4_prompt", lambda *_a, **_k: "## Analysis\n\nDS4 body")
+    summary = summarize.summarize_with_ds4("Raw content", language="en", style="analysis", deadline=None)
+    assert "DS4 body" in summary
     assert "informational purposes only" in summary
 
 
@@ -706,7 +718,7 @@ def test_generate_briefing_zero_deadline_disables_timeout(capsys, monkeypatch):
     monkeypatch.setattr(summarize, "datetime", FixedDateTime)
     monkeypatch.setattr(
         summarize,
-        "summarize_with_kimi",
+        "summarize_with_qwen",
         lambda *_a, **_k: (
             "### Märkte\nAlles ruhig.\n\n"
             "### Stimmung\nNeutral.\n\n"
@@ -723,7 +735,7 @@ def test_generate_briefing_zero_deadline_disables_timeout(capsys, monkeypatch):
             "lang": "de",
             "style": "briefing",
             "time": None,
-            "model": "kimi",
+            "model": "qwen",
             "json": True,
             "research": False,
             "deadline": 0.0,
@@ -736,10 +748,10 @@ def test_generate_briefing_zero_deadline_disables_timeout(capsys, monkeypatch):
     summarize.generate_briefing(args)
     payload = json.loads(capsys.readouterr().out)
     assert payload["summary_mode"] == "llm"
-    assert payload["summary_model_used"] == "kimi"
+    assert payload["summary_model_used"] == "qwen"
 
 
-def test_generate_briefing_falls_back_to_gemini_when_kimi_unavailable(capsys, monkeypatch):
+def test_generate_briefing_falls_back_to_ds4_when_qwen_unavailable(capsys, monkeypatch):
     def fake_market_news(*_args, **_kwargs):
         return {
             "headlines": [
@@ -761,10 +773,10 @@ def test_generate_briefing_falls_back_to_gemini_when_kimi_unavailable(capsys, mo
     monkeypatch.setattr(summarize, "get_portfolio_news", lambda *_a, **_k: None)
     monkeypatch.setattr(summarize, "get_portfolio_movers", lambda *_a, **_k: {"movers": []})
     monkeypatch.setattr(summarize, "datetime", FixedDateTime)
-    monkeypatch.setattr(summarize, "summarize_with_kimi", lambda *_a, **_k: "⚠️ Kimi briefing error: ollama CLI not found")
+    monkeypatch.setattr(summarize, "summarize_with_qwen", lambda *_a, **_k: "⚠️ Qwen briefing error: KALLIOPE_SERVING_API_KEY not set")
     monkeypatch.setattr(
         summarize,
-        "summarize_with_gemini",
+        "summarize_with_ds4",
         lambda *_a, **_k: (
             "### Markets\nQuiet.\n\n"
             "### Sentiment\nNeutral.\n\n"
@@ -781,7 +793,7 @@ def test_generate_briefing_falls_back_to_gemini_when_kimi_unavailable(capsys, mo
             "lang": "en",
             "style": "briefing",
             "time": None,
-            "model": "kimi",
+            "model": "qwen",
             "json": True,
             "research": False,
             "deadline": None,
@@ -793,11 +805,11 @@ def test_generate_briefing_falls_back_to_gemini_when_kimi_unavailable(capsys, mo
 
     summarize.generate_briefing(args)
     payload = json.loads(capsys.readouterr().out)
-    assert payload["summary_model_used"] == "gemini"
+    assert payload["summary_model_used"] == "ds4"
     assert "### Markets" in payload["summary"]
 
 
-def test_generate_analysis_falls_back_to_gemini_when_kimi_unavailable(monkeypatch, capsys):
+def test_generate_analysis_falls_back_to_ds4_when_qwen_unavailable(monkeypatch, capsys):
     def fake_market_news(*_args, **_kwargs):
         return {
             "headlines": [
@@ -817,8 +829,8 @@ def test_generate_analysis_falls_back_to_gemini_when_kimi_unavailable(monkeypatc
     monkeypatch.setattr(summarize, "get_portfolio_news", lambda *_a, **_k: None)
     monkeypatch.setattr(summarize, "get_portfolio_movers", lambda *_a, **_k: {"movers": []})
     monkeypatch.setattr(summarize, "datetime", FixedDateTime)
-    monkeypatch.setattr(summarize, "summarize_with_kimi", lambda *_a, **_k: "⚠️ Kimi briefing error: ollama CLI not found")
-    monkeypatch.setattr(summarize, "summarize_with_gemini", lambda *_a, **_k: "## Analysis\n\nGemini analysis body")
+    monkeypatch.setattr(summarize, "summarize_with_qwen", lambda *_a, **_k: "⚠️ Qwen briefing error: KALLIOPE_SERVING_API_KEY not set")
+    monkeypatch.setattr(summarize, "summarize_with_ds4", lambda *_a, **_k: "## Analysis\n\nDS4 analysis body")
 
     args = type(
         "Args",
@@ -827,7 +839,7 @@ def test_generate_analysis_falls_back_to_gemini_when_kimi_unavailable(monkeypatc
             "lang": "en",
             "style": "analysis",
             "time": None,
-            "model": "kimi",
+            "model": "qwen",
             "json": True,
             "research": False,
             "deadline": None,
@@ -839,11 +851,11 @@ def test_generate_analysis_falls_back_to_gemini_when_kimi_unavailable(monkeypatc
 
     summarize.generate_briefing(args)
     payload = json.loads(capsys.readouterr().out)
-    assert payload["summary_model_used"] == "gemini"
-    assert "Gemini analysis body" in payload["summary"]
+    assert payload["summary_model_used"] == "ds4"
+    assert "DS4 analysis body" in payload["summary"]
 
 
-def test_generate_analysis_uses_kimi_even_without_llm_flag(capsys, monkeypatch):
+def test_generate_analysis_uses_qwen_even_without_llm_flag(capsys, monkeypatch):
     def fake_market_news(*_args, **_kwargs):
         return {
             "headlines": [
@@ -867,11 +879,11 @@ def test_generate_analysis_uses_kimi_even_without_llm_flag(capsys, monkeypatch):
 
     calls = {}
 
-    def fake_kimi(content, language, style, deadline=None):
+    def fake_qwen(content, language, style, deadline=None):
         calls["style"] = style
-        return "## Analysis\n\nKimi analysis body"
+        return "## Analysis\n\nQwen analysis body"
 
-    monkeypatch.setattr(summarize, "summarize_with_kimi", fake_kimi)
+    monkeypatch.setattr(summarize, "summarize_with_qwen", fake_qwen)
 
     args = type(
         "Args",
@@ -880,7 +892,7 @@ def test_generate_analysis_uses_kimi_even_without_llm_flag(capsys, monkeypatch):
             "lang": "en",
             "style": "analysis",
             "time": None,
-            "model": "kimi",
+            "model": "qwen",
             "json": True,
             "research": False,
             "deadline": None,
@@ -894,8 +906,8 @@ def test_generate_analysis_uses_kimi_even_without_llm_flag(capsys, monkeypatch):
     payload = json.loads(capsys.readouterr().out)
     assert calls["style"] == "analysis"
     assert payload["summary_mode"] == "llm"
-    assert payload["summary_model_used"] == "kimi"
-    assert "Kimi analysis body" in payload["summary"]
+    assert payload["summary_model_used"] == "qwen"
+    assert "Qwen analysis body" in payload["summary"]
 
 
 # --- Tests for watchpoints feature (Issue #92) ---
@@ -1197,7 +1209,7 @@ class TestBuildWatchpointsData:
         assert result.market_wide is True
 
 
-def test_generate_briefing_defaults_to_kimi_path(capsys, monkeypatch):
+def test_generate_briefing_defaults_to_qwen_path(capsys, monkeypatch):
     def fake_market_news(*_args, **_kwargs):
         return {
             "headlines": [{"source": "CNBC", "title": "Headline one", "link": "https://example.com/1"}],
@@ -1209,7 +1221,7 @@ def test_generate_briefing_defaults_to_kimi_path(capsys, monkeypatch):
     monkeypatch.setattr(summarize, "get_portfolio_movers", lambda *_a, **_k: {"movers": []})
     monkeypatch.setattr(summarize, "datetime", FixedDateTime)
     monkeypatch.setattr(summarize, "validate_briefing_structure", lambda *_a, **_k: (True, []))
-    monkeypatch.setattr(summarize, "summarize_with_kimi", lambda *_a, **_k: "### Märkte\n\nAlles ruhig.\n\n### Stimmung\n\nNeutral.\n\n### Top 5 Schlagzeilen\n1. Headline one\n\n### Portfolio-Auswirkung\nBeobachten.\n\n### Beobachtungspunkte\n- Watch one")
+    monkeypatch.setattr(summarize, "summarize_with_qwen", lambda *_a, **_k: "### Märkte\n\nAlles ruhig.\n\n### Stimmung\n\nNeutral.\n\n### Top 5 Schlagzeilen\n1. Headline one\n\n### Portfolio-Auswirkung\nBeobachten.\n\n### Beobachtungspunkte\n- Watch one")
 
     args = type(
         "Args",
@@ -1218,7 +1230,7 @@ def test_generate_briefing_defaults_to_kimi_path(capsys, monkeypatch):
             "lang": "de",
             "style": "briefing",
             "time": None,
-            "model": "kimi",
+            "model": "qwen",
             "json": True,
             "research": False,
             "deadline": None,
@@ -1231,7 +1243,7 @@ def test_generate_briefing_defaults_to_kimi_path(capsys, monkeypatch):
     summarize.generate_briefing(args)
     payload = json.loads(capsys.readouterr().out)
     assert payload["summary_mode"] == "llm"
-    assert payload["summary_model_used"] == "kimi"
+    assert payload["summary_model_used"] == "qwen"
 
 
 def test_generate_analysis_hard_fails_when_configured_fallbacks_fail(monkeypatch):
@@ -1245,8 +1257,8 @@ def test_generate_analysis_hard_fails_when_configured_fallbacks_fail(monkeypatch
     monkeypatch.setattr(summarize, "get_portfolio_news", lambda *_a, **_k: None)
     monkeypatch.setattr(summarize, "get_portfolio_movers", lambda *_a, **_k: {"movers": []})
     monkeypatch.setattr(summarize, "datetime", FixedDateTime)
-    monkeypatch.setenv("FINANCE_NEWS_SUMMARY_FALLBACKS", "kimi")
-    monkeypatch.setattr(summarize, "summarize_with_kimi", lambda *_a, **_k: "⚠️ Kimi briefing error: ollama CLI not found")
+    monkeypatch.setenv("FINANCE_NEWS_SUMMARY_FALLBACKS", "qwen")
+    monkeypatch.setattr(summarize, "summarize_with_qwen", lambda *_a, **_k: "⚠️ Qwen briefing error: KALLIOPE_SERVING_API_KEY not set")
 
     args = type(
         "Args",
@@ -1255,7 +1267,7 @@ def test_generate_analysis_hard_fails_when_configured_fallbacks_fail(monkeypatch
             "lang": "en",
             "style": "analysis",
             "time": None,
-            "model": "kimi",
+            "model": "qwen",
             "json": True,
             "research": False,
             "deadline": None,
@@ -1266,5 +1278,5 @@ def test_generate_analysis_hard_fails_when_configured_fallbacks_fail(monkeypatch
     )()
 
     import pytest
-    with pytest.raises(RuntimeError, match="ollama CLI not found"):
+    with pytest.raises(RuntimeError, match="KALLIOPE_SERVING_API_KEY"):
         summarize.generate_briefing(args)

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -31,7 +31,12 @@ lobster "workflows.run --file workflows/briefing.yaml --args-json '{\"time\":\"e
 |----------|-------------|
 | `FINANCE_NEWS_CHANNEL` | Default channel: `whatsapp` or `telegram` |
 | `FINANCE_NEWS_TARGET` | Default target (group name, phone, chat ID) |
-| `KIMI_API_KEY` | Enables direct Kimi briefing generation inside Docker |
+| `KALLIOPE_SERVING_API_KEY` | Bearer token for the local Qwen route (required for briefing generation inside Docker) |
+| `FINANCE_NEWS_QWEN_BASE_URL` | Override the Qwen route base URL (default `http://100.124.155.99:4000/v1`) |
+| `FINANCE_NEWS_QWEN_MODEL` | Override the Qwen model (default `qwen3.6:35b-a3b`) |
+| `FINANCE_NEWS_DS4_BASE_URL` | Override the DS4 fallback route base URL (default `http://gx10r-head:8888/v1`) |
+| `FINANCE_NEWS_DS4_MODEL` | Override the DS4 model (default `deepseek-v4-flash-dspark`) |
+| `FINANCE_NEWS_DS4_API_KEY` | Optional bearer token for the DS4 route (unset for the tailnet vLLM) |
 
 **Examples:**
 ```bash

--- a/workflows/briefing-cron.yaml
+++ b/workflows/briefing-cron.yaml
@@ -41,10 +41,14 @@ steps:
         OPENBB_MOUNT="-v $OPENBB_BIN:/usr/local/bin/openbb-quote:ro"
       fi
       docker run --rm \
+        --network host \
         --workdir /app \
-        -e KIMI_API_KEY \
-        -e KIMI_API_BASE_URL \
-        -e FINANCE_NEWS_KIMI_MODEL \
+        -e KALLIOPE_SERVING_API_KEY \
+        -e FINANCE_NEWS_QWEN_BASE_URL \
+        -e FINANCE_NEWS_QWEN_MODEL \
+        -e FINANCE_NEWS_DS4_BASE_URL \
+        -e FINANCE_NEWS_DS4_MODEL \
+        -e FINANCE_NEWS_DS4_API_KEY \
         -v "$SKILL_DIR/config:/app/config:ro" \
         -v "$SKILL_DIR/scripts:/app/scripts:ro" \
         $OPENBB_MOUNT \
@@ -80,7 +84,7 @@ steps:
       STRUCT_OK=$(jq -r '.summary_structure_ok // false' "$OUTFILE")
 
       case "$MODEL_USED" in
-        kimi) ;;
+        qwen|ds4) ;;
         *)
           echo "❌ Refusing to send briefing from unsupported writer"
           jq '{summary_mode, summary_model_used, summary_structure_ok, summary_missing_sections, generator}' "$OUTFILE"

--- a/workflows/briefing.yaml
+++ b/workflows/briefing.yaml
@@ -41,10 +41,14 @@ steps:
         OPENBB_MOUNT="-v $OPENBB_BIN:/usr/local/bin/openbb-quote:ro"
       fi
       docker run --rm \
+        --network host \
         --workdir /app \
-        -e KIMI_API_KEY \
-        -e KIMI_API_BASE_URL \
-        -e FINANCE_NEWS_KIMI_MODEL \
+        -e KALLIOPE_SERVING_API_KEY \
+        -e FINANCE_NEWS_QWEN_BASE_URL \
+        -e FINANCE_NEWS_QWEN_MODEL \
+        -e FINANCE_NEWS_DS4_BASE_URL \
+        -e FINANCE_NEWS_DS4_MODEL \
+        -e FINANCE_NEWS_DS4_API_KEY \
         -v "$SKILL_DIR/config:/app/config:ro" \
         -v "$SKILL_DIR/scripts:/app/scripts:ro" \
         $OPENBB_MOUNT \
@@ -80,7 +84,7 @@ steps:
       STRUCT_OK=$(jq -r '.summary_structure_ok // false' "$OUTFILE")
 
       case "$MODEL_USED" in
-        kimi) ;;
+        qwen|ds4) ;;
         *)
           echo "❌ Refusing to send briefing from unsupported writer"
           jq '{summary_mode, summary_model_used, summary_structure_ok, summary_missing_sections, generator}' "$OUTFILE"


### PR DESCRIPTION
## What Problem This Solves

Ollama Cloud pauses **2026-07-23**. finance-news ran selection/summarize/translation on Kimi (Anthropic-style Kimi Coding API + `ollama run kimi-k2.6:cloud`) with a Gemini-CLI fallback, and deep-research on Kimi Cloud — all break at the pause.

## Why This Change Was Made

Units U5/U7 of the Ollama Cloud pause migration. Move every model path to LOCAL routes.

- **New shared helper `scripts/utils.call_openai_chat`** — a fail-closed OpenAI-compatible client (bearer in the `Authorization` header only, bounded timeout, non-2xx/empty/non-JSON → error sentinel, **no Cloud fallback anywhere**).
- **Selection / summarize / translation → Qwen** (`http://100.124.155.99:4000/v1`, `qwen3.6:35b-a3b`, `KALLIOPE_SERVING_API_KEY`) with a local **DS4** fallback.
- **Deep research (`research.py`) → DS4-high** (`http://gx10r-head:8888/v1`, `deepseek-v4-flash-dspark`) primary, Qwen fallback, raw-data last. *(Note: the U2 manifest coarsely classified research.py as Qwen; DS4-high is the deep-research/materiality tier per the three-tier policy — both local, env-overridable. Flagged for owner confirmation.)*
- Removed the dead Kimi/Gemini code (`_run_kimi_api_prompt`, `_run_prompt_command`, `_extract_anthropic_text`, availability probes, unused imports). Renamed `{kimi,gemini}`→`{qwen,ds4}` across config model-order arrays, CLI defaults, and the workflow writer gate. Workflows/Dockerfile pass the local-route env; the two `docker run` blocks add `--network host` so the container can reach the tailnet endpoints.

## User Impact

None yet. At the pause, finance-news runs entirely on local models; no Cloud dependency, no cloud spend.

## Evidence

- `./venv/bin/python -m pytest -q` → **208 passed** (30% gate; model-path tests rewritten to assert the local OpenAI-compatible routes — non-vacuous, success path exercised end-to-end through the real helper).
- Correctness review (independent): migration correct; the new helper has **no token-leak and no fail-open path**; repo-wide grep finds no `kimi|gemini|agy|ollama|:cloud|anthropic|minimax`.

## Risk and Rollout

Low-medium (real refactor, but fully test-covered + reviewed). Env-overridable routes. **Flagged for review:** the `docker run --network host` (needed for tailnet reachability) shares the host network namespace — consider a scoped docker network exposing only the two tailnet routes if you want to reduce the container's loopback reach. Live-enable note: if kalliope defaults thinking ON for qwen3.6, validate the token budgets during the staging/live-proof step.

## AI Assistance

Used (delegated implementation, independently correctness-reviewed incl. a token-leak/fail-open audit of the new helper, tests pass). I understand this code.