### PR TITLE
docs: dedupe cron block from SKILL.md (COMMANDS.md owns it)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -47,24 +47,7 @@ See [COMMANDS.md](COMMANDS.md) for the full CLI reference including portfolio ma
 
 ## Cron Jobs
 
-```bash
-# Add morning briefing (6:30 AM PT, weekdays)
-openclaw cron add --schedule "30 6 * * 1-5" \
-  --timezone "America/Los_Angeles" \
-  --command "bash ~/clawd/skills/finance-news/cron/morning.sh"
-
-# Add evening briefing (1:00 PM PT, weekdays)
-openclaw cron add --schedule "0 13 * * 1-5" \
-  --timezone "America/Los_Angeles" \
-  --command "bash ~/clawd/skills/finance-news/cron/evening.sh"
-```
-
-Verify cron jobs are active:
-
-```bash
-openclaw cron list
-bash ~/clawd/skills/finance-news/cron/morning.sh  # Manual test run
-```
+Scheduled morning/evening briefings run via `openclaw cron` — the add/verify commands (and the manual crontab fallback) live in [COMMANDS.md](COMMANDS.md) → Cron Jobs. Quick check: `openclaw cron list`.
 
 ## Integration
 


### PR DESCRIPTION
## What Problem This Solves

SKILL.md restated the `openclaw cron add` morning/evening commands near-verbatim from COMMANDS.md — right after pointing at COMMANDS.md as the full CLI reference. Two copies of scheduling commands drift.

## Why This Change Was Made

Context-engineering audit: single source. COMMANDS.md → Cron Jobs (which also carries the manual crontab fallback) owns the commands; SKILL.md keeps a pointer plus the `openclaw cron list` quick check.

## User Impact

No information lost; on-invocation SKILL.md is slightly leaner and can no longer contradict COMMANDS.md. THEORY.MD was left deliberately unlinked: it is marked SUPERSEDED in its own header and belongs to history, not the live reference graph.

## Risk and Rollout

Minimal; one section in one doc. The load-bearing troubleshooting table (Kalliope/DS4 routes) untouched.

## Evidence

- COMMANDS.md lines 61-90 verified to contain the identical cron add/verify commands plus the crontab fallback.